### PR TITLE
Fixed conversation checkpoint and option to turn off chat events

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -236,8 +236,7 @@ public class Conversation implements Listener {
         if (ended) return;
         ended = true;
         inOut.end();
-        // set conversation null on database
-        Connector con = new Connector();
+        // set conversation to null on database
         BetonQuest.getInstance().getSaver().add(new Record(
                 UpdateType.UPDATE_CONVERSATION, new String[] { "null", playerID }));
         // fire final events

--- a/src/main/java/pl/betoncraft/betonquest/database/Connector.java
+++ b/src/main/java/pl/betoncraft/betonquest/database/Connector.java
@@ -59,6 +59,9 @@ public class Connector {
         try {
             PreparedStatement statement;
             switch (type) {
+            	case CHECK_PLAYER:
+                    statement = connection.prepareStatement("SELECT 1 FROM " + prefix + "player WHERE playerID = ?;");
+                    break;
                 case SELECT_JOURNAL:
                     statement = connection.prepareStatement("SELECT pointer, date FROM " + prefix + "journal WHERE playerID = ?;");
                     break;
@@ -153,6 +156,9 @@ public class Connector {
                     break;
                 case ADD_PLAYER:
                     statement = connection.prepareStatement("INSERT INTO " + prefix + "player (playerID, language) VALUES (?, ?);");
+                    break;
+                case ADD_CONVERSATION:
+                    statement = connection.prepareStatement("INSERT INTO " + prefix + "player (playerID, language, conversation) VALUES (?, ?, ?);");
                     break;
                 case REMOVE_OBJECTIVES:
                     statement = connection.prepareStatement("DELETE FROM " + prefix + "objectives WHERE playerID = ? AND objective = ?;");
@@ -255,6 +261,8 @@ public class Connector {
      * Type of the query
      */
     public enum QueryType {
+    	
+    	CHECK_PLAYER,
 
         SELECT_OBJECTIVES, SELECT_TAGS, SELECT_POINTS, SELECT_JOURNAL, SELECT_BACKPACK, SELECT_PLAYER,
 
@@ -294,6 +302,10 @@ public class Connector {
          * Add single player to the database. PlayerID, language.
          */
         ADD_PLAYER,
+        /**
+         * Add conversation checkpoint. PlayerID, language, conversation.
+         */
+        ADD_CONVERSATION,
         /**
          * Removes the single objective from the database. PlayerID, objectiveID.
          */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,7 @@ combat_delay: '10'
 notify_pullback: 'true'
 default_package: default
 remove_items_after_respawn: 'true'
+conversation_events_log: 'true'
 sounds:
   start: VILLAGER_HAGGLE
   end: VILLAGER_YES


### PR DESCRIPTION
- Check for existing player row on conversation suspend() and update/add
it
- Set conversation to null in player row in endConversation()
- add "conversation_events_log" option to config to turn on/off chat
conversation start/end/command messages

Signed-off-by: GioBozza <giovanni.bozzano.1996@gmail.com>