### PR TITLE
Adding backwards compatible support for questnames

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/config/Config.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/Config.java
@@ -408,7 +408,7 @@ public class Config {
         if (prefixName != null) {
             String prefix = getMessage(language, prefixName, prefixVariables);
             if (prefix.length() > 0) {
-                message = prefix + " " + message;
+                message = prefix + message;
             }
         }
         player.sendMessage(message);

--- a/src/main/java/pl/betoncraft/betonquest/config/Config.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/Config.java
@@ -330,7 +330,7 @@ public class Config {
     }
     
     /**
-     * Sends a message to player in his choosen language or default
+     * Sends a message to player in his chosen language or default
      * or English (if previous not found).
      * 
      * @param playerID
@@ -339,11 +339,11 @@ public class Config {
      *          ID of the message
      */
     public static void sendMessage(String playerID, String messageName) {
-        sendMessage(playerID, messageName, null, null);
+        sendMessage(playerID, messageName, null, null, null, null);
     }
     
     /**
-     * Sends a message to player in his choosen language or default
+     * Sends a message to player in his chosen language or default
      * or English (if previous not found). It will replace all {x}
      * sequences with the variables.
      * 
@@ -356,11 +356,11 @@ public class Config {
      */
     public static void sendMessage(String playerID, String messageName,
             String[] variables) {
-        sendMessage(playerID, messageName, variables, null);
+        sendMessage(playerID, messageName, variables, null, null, null);
     }
     
     /**
-     * Sends a message to player in his choosen language or default
+     * Sends a message to player in his chosen language or default
      * or English (if previous not found). It will replace all {x}
      * sequences with the variables and play the sound.
      * 
@@ -370,17 +370,47 @@ public class Config {
      *          ID of the message
      * @param variables
      *          array of variables which will be inserted into the string
-     * @param sound
+     * @param soundName
      *          name of the sound to play to the player
      */
     public static void sendMessage(String playerID, String messageName,
             String[] variables, String soundName) {
+        sendMessage(playerID, messageName, variables, soundName, null, null);
+    }
+    
+    /**
+     * Sends a message to player in his chosen language or default
+     * or English (if previous not found). It will replace all {x}
+     * sequences with the variables and play the sound. It will also
+     * add a prefix to the message.
+     * 
+     * @param playerID
+     *          ID of the player
+     * @param messageName
+     *          ID of the message
+     * @param variables
+     *          array of variables which will be inserted into the message
+     * @param soundName
+     *          name of the sound to play to the player
+     * @param prefixName
+     *          ID of the prefix
+     * @param prefixVariables
+     *          array of variables which will be inserted into the prefix
+     */
+    public static void sendMessage(String playerID, String messageName,
+            String[] variables, String soundName, String prefixName, String[] prefixVariables) {
         Player player = PlayerConverter.getPlayer(playerID);
         DatabaseHandler dbHandler = BetonQuest.getInstance().getDBHandler(playerID);
         if (player == null || dbHandler == null) return;
         String language = dbHandler.getLanguage();
         String message = getMessage(language, messageName, variables);
         if (message.length() == 0) return;
+        if (prefixName != null) {
+            String prefix = getMessage(language, prefixName, prefixVariables);
+            if (prefix.length() > 0) {
+                message = prefix + " " + message;
+            }
+        }
         player.sendMessage(message);
         if (soundName != null) {
             String rawSound = BetonQuest.getInstance().getConfig().getString(

--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -137,40 +137,42 @@ public class Conversation implements Listener {
         
         new Starter(options).runTaskAsynchronously(BetonQuest.getInstance());
     }
-    
+
     /**
      * Chooses the first available option.
+     * Note: this method was logically separated from printNPCText()
      * 
      * @param options
-     * 				list of option pointers separated by commas
+     *            list of option pointers separated by commas
      * @param force
-     * 				setting it to true will force the first option, even if
-     * 				conditions are not met
+     *            setting it to true will force the first option, even if
+     *            conditions are not met
      */
     private void selectOption(String[] options, boolean force) {
-    	
-		if (!force) {
-			// get npc's text
-			option = null;
-			options:
-			for (String NPCoption : options) {
-		 		for (String condition : data.getData(NPCoption, OptionType.NPC,
-		 				RequestType.CONDITION)) {
-					if (!BetonQuest.condition(this.playerID, condition)) {
-						continue options;
-					}
-				}
-				option = NPCoption;
-				break;
-			}
-		} else {
-			option = options[0];
-		}
-	}
+
+        if (!force) {
+            // get npc's text
+            option = null;
+            options:
+            for (String NPCoption : options) {
+                for (String condition : data.getData(NPCoption, OptionType.NPC,
+                        RequestType.CONDITION)) {
+                    if (!BetonQuest.condition(this.playerID, condition)) {
+                        continue options;
+                    }
+                }
+                option = NPCoption;
+                break;
+            }
+        } else {
+            option = options[0];
+        }
+    }
 
     /**
      * Sends to the player the text said by NPC. It uses the selected
      * option and displays it.
+     * Note: this method now requires a prior call to selectOption()
      */
     private void printNPCText() {
 
@@ -410,23 +412,28 @@ public class Conversation implements Listener {
                 options = data.getStartingOptions();
                 force = false;
                 
+                // first select the option before sending message, so it
+                // knows which is used
                 selectOption(options, force);
                 String questName = data.getQuestName(option);
                 
                 // print message about starting a conversation only if it
                 // is started, not resumed
+                // send the appropriate message depending on whether a questname
+                // was specified
                 if (!questName.equals("")) {
-                	Config.sendMessage(playerID, "conversation_start_named",
-                		new String[]{data.getQuester(language), questName}, "start");
+                    Config.sendMessage(playerID, "conversation_start_named",
+                        new String[]{data.getQuester(language), questName}, "start");
                 }
                 else {
-                	Config.sendMessage(playerID, "conversation_start",
-                		new String[]{data.getQuester(language)}, "start");
+                    Config.sendMessage(playerID, "conversation_start",
+                        new String[]{data.getQuester(language)}, "start");
                 }
             }
             else {
-        		selectOption(options, force);
-        	}
+                // don't forget to select the option prior to printing its text
+                selectOption(options, force);
+            }
             
             // print NPC's text
             printNPCText();
@@ -493,8 +500,9 @@ public class Conversation implements Listener {
         }
 
         public void run() {
-        	selectOption(data.getData(option,
-        			OptionType.PLAYER, RequestType.POINTER), false);
+            // don't forget to select the option prior to printing its text
+            selectOption(data.getData(option,
+                    OptionType.PLAYER, RequestType.POINTER), false);
             // print to player npc's answer
             printNPCText();
         }

--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -415,15 +415,15 @@ public class Conversation implements Listener {
                 // first select the option before sending message, so it
                 // knows which is used
                 selectOption(options, force);
-                String questName = data.getQuestName(option);
+                String prefix = data.getPrefix(option);
                 
                 // print message about starting a conversation only if it
                 // is started, not resumed
-                // send the appropriate message depending on whether a questname
+                // send the appropriate message depending on whether a prefix
                 // was specified
-                if (!questName.equals("")) {
+                if (prefix != null) {
                     Config.sendMessage(playerID, "conversation_start_named",
-                        new String[]{data.getQuester(language), questName}, "start");
+                        new String[]{data.getQuester(language), prefix}, "start");
                 }
                 else {
                     Config.sendMessage(playerID, "conversation_start",

--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -415,20 +415,21 @@ public class Conversation implements Listener {
                 // first select the option before sending message, so it
                 // knows which is used
                 selectOption(options, force);
-                String prefix = data.getPrefix(option);
+                
+                // check whether to add a prefix
+                String prefix = data.getPrefix(language, option);
+                String prefixName = null;
+                String[] prefixVariables = null;
+                if (prefix != null) {
+                    prefixName = "conversation_prefix";
+                    prefixVariables = new String[]{prefix};
+                }
                 
                 // print message about starting a conversation only if it
                 // is started, not resumed
-                // send the appropriate message depending on whether a prefix
-                // was specified
-                if (prefix != null) {
-                    Config.sendMessage(playerID, "conversation_start_named",
-                        new String[]{data.getQuester(language), prefix}, "start");
-                }
-                else {
-                    Config.sendMessage(playerID, "conversation_start",
-                        new String[]{data.getQuester(language)}, "start");
-                }
+                Config.sendMessage(playerID, "conversation_start",
+                    new String[]{data.getQuester(language)}, "start",
+                    prefixName, prefixVariables);
             }
             else {
                 // don't forget to select the option prior to printing its text

--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -411,11 +411,18 @@ public class Conversation implements Listener {
                 force = false;
                 
                 selectOption(options, force);
+                String questName = data.getQuestName(option);
                 
                 // print message about starting a conversation only if it
                 // is started, not resumed
-                Config.sendMessage(playerID, "conversation_start",
-                        new String[]{data.getQuester(language), data.getQuestName(option)}, "start");
+                if (!questName.equals("")) {
+                	Config.sendMessage(playerID, "conversation_start_named",
+                		new String[]{data.getQuester(language), questName}, "start");
+                }
+                else {
+                	Config.sendMessage(playerID, "conversation_start",
+                		new String[]{data.getQuester(language)}, "start");
+                }
             }
             else {
         		selectOption(options, force);

--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -140,7 +140,6 @@ public class Conversation implements Listener {
 
     /**
      * Chooses the first available option.
-     * Note: this method was logically separated from printNPCText()
      * 
      * @param options
      *            list of option pointers separated by commas
@@ -430,8 +429,7 @@ public class Conversation implements Listener {
                 Config.sendMessage(playerID, "conversation_start",
                     new String[]{data.getQuester(language)}, "start",
                     prefixName, prefixVariables);
-            }
-            else {
+            } else {
                 // don't forget to select the option prior to printing its text
                 selectOption(options, force);
             }

--- a/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
@@ -39,6 +39,7 @@ public class ConversationData {
     private String convName;
     
     private HashMap<String, String> quester = new HashMap<>(); // maps for multiple languages
+    private String questName;
     private String[] finalEvents;
     private String[] startingOptions;
     private boolean blockMovement;
@@ -69,6 +70,8 @@ public class ConversationData {
         } else {
             quester.put(Config.getLanguage(), pack.getString("conversations." + name + ".quester"));
         }
+        String questName = pack.getString("conversations." + name + ".questname");
+    	this.questName = (questName != null && !questName.equals("")) ? questName : "";
         String rawFinalEvents = pack.getString("conversations." + name + ".final_events");
         String rawStartingOptions = pack.getString("conversations." + name + ".first");
         String stop = pack.getString("conversations." + name + ".stop");
@@ -138,6 +141,19 @@ public class ConversationData {
     }
     
     /**
+     * Gets the name of the quest.
+     * If provided NPC option does not define it, the global one from the conversation is used instead.
+     * 
+     * @param option
+     * 			the quest starting npc option that contains the name of the quest
+     * @return the quest's name
+     */
+    public String getQuestName(String option) {
+		String questname = ((Option)this.NPCOptions.get(option)).getInlineQuestName();
+		return !questname.equals("") ? questname : this.questName;
+	}
+    
+    /**
      * @param lang
      *          language of quester's name
      * @return the quester's name
@@ -199,6 +215,7 @@ public class ConversationData {
     
     private interface Option {
         public String getName();
+        public abstract String getInlineQuestName();
         public String getText(String lang);
         public String[] getConditions();
         public String[] getEvents();
@@ -211,6 +228,7 @@ public class ConversationData {
     private class NPCOption implements Option {
         
         private String name;
+        private String inlineQuestName;
         
         private HashMap<String, String> text = new HashMap<>();
         private String[] conditions;
@@ -220,6 +238,8 @@ public class ConversationData {
         public NPCOption(String name) throws InstructionParseException {
             this.name = name;
             String defaultLang = Config.getLanguage();
+            String questname = pack.getString("conversations." + convName + ".NPC_options." + name + ".questname");
+        	this.inlineQuestName = (questname != null && !questname.equals("")) ? questname : "";
             if (pack.getConversation(convName).getConfig()
                     .isConfigurationSection("NPC_options." + name + ".text")) {
                 for (String lang : pack.getConversation(convName).getConfig()
@@ -315,6 +335,10 @@ public class ConversationData {
         public String getName() {
             return name;
         }
+        
+        public String getInlineQuestName() {
+    		return this.inlineQuestName;
+    	}
         
         public String getText(String lang) {
             String theText = text.get(lang);
@@ -448,6 +472,10 @@ public class ConversationData {
         public String getName() {
             return name;
         }
+        
+        public String getInlineQuestName() {
+    		return "";
+    	}
         
         public String getText(String lang) {
             String theText = text.get(lang);

--- a/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
@@ -73,15 +73,13 @@ public class ConversationData {
         if (conv.isConfigurationSection("prefix")) {
             for (String lang : conv.getConfigurationSection("prefix").getKeys(false)) {
                 String pref = pack.getString("conversations." + name + ".prefix." + lang);
-                if (pref != null && !pref.equals(""))
-                {
+                if (pref != null && !pref.equals("")) {
                     prefix.put(lang, pref);
                 }
             }
         } else {
             String pref = pack.getString("conversations." + name + ".prefix");
-            if (pref != null && !pref.equals(""))
-            {
+            if (pref != null && !pref.equals("")) {
                 prefix.put(Config.getLanguage(), pref);
             }
         }

--- a/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
@@ -71,7 +71,7 @@ public class ConversationData {
             quester.put(Config.getLanguage(), pack.getString("conversations." + name + ".quester"));
         }
         String questName = pack.getString("conversations." + name + ".questname");
-    	this.questName = (questName != null && !questName.equals("")) ? questName : "";
+        this.questName = (questName != null && !questName.equals("")) ? questName : "";
         String rawFinalEvents = pack.getString("conversations." + name + ".final_events");
         String rawStartingOptions = pack.getString("conversations." + name + ".first");
         String stop = pack.getString("conversations." + name + ".stop");
@@ -142,16 +142,17 @@ public class ConversationData {
     
     /**
      * Gets the name of the quest.
-     * If provided NPC option does not define it, the global one from the conversation is used instead.
+     * If provided NPC option does not define it, the global one from the conversation is returned
+     * instead.
      * 
      * @param option
-     * 			the quest starting npc option that contains the name of the quest
+     *          the quest starting npc option that contains the name of the quest
      * @return the quest's name
      */
     public String getQuestName(String option) {
-		String questname = ((Option)this.NPCOptions.get(option)).getInlineQuestName();
-		return !questname.equals("") ? questname : this.questName;
-	}
+        String questname = ((Option)this.NPCOptions.get(option)).getInlineQuestName();
+        return !questname.equals("") ? questname : this.questName;
+    }
     
     /**
      * @param lang
@@ -238,8 +239,9 @@ public class ConversationData {
         public NPCOption(String name) throws InstructionParseException {
             this.name = name;
             String defaultLang = Config.getLanguage();
-            String questname = pack.getString("conversations." + convName + ".NPC_options." + name + ".questname");
-        	this.inlineQuestName = (questname != null && !questname.equals("")) ? questname : "";
+            String questname = pack.getString("conversations." + convName
+                    + ".NPC_options." + name + ".questname");
+            this.inlineQuestName = (questname != null && !questname.equals("")) ? questname : "";
             if (pack.getConversation(convName).getConfig()
                     .isConfigurationSection("NPC_options." + name + ".text")) {
                 for (String lang : pack.getConversation(convName).getConfig()
@@ -337,8 +339,8 @@ public class ConversationData {
         }
         
         public String getInlineQuestName() {
-    		return this.inlineQuestName;
-    	}
+            return this.inlineQuestName;
+        }
         
         public String getText(String lang) {
             String theText = text.get(lang);
@@ -474,8 +476,8 @@ public class ConversationData {
         }
         
         public String getInlineQuestName() {
-    		return "";
-    	}
+            return "";
+        }
         
         public String getText(String lang) {
             String theText = text.get(lang);

--- a/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
@@ -39,7 +39,7 @@ public class ConversationData {
     private String convName;
     
     private HashMap<String, String> quester = new HashMap<>(); // maps for multiple languages
-    private HashMap<String, String> prefix = new HashMap<>();
+    private HashMap<String, String> prefix = new HashMap<>(); // global conversation prefix
     private String[] finalEvents;
     private String[] startingOptions;
     private boolean blockMovement;
@@ -158,13 +158,26 @@ public class ConversationData {
      * If provided NPC option does not define one, the global one from the conversation is returned
      * instead.
      * 
+     * @param lang
+     *          language of the prefix
      * @param option
      *          the quest starting npc option that defines the prefix of the conversation
      * @return the conversation prefix, or null if not defined
      */
-    public String getPrefix(String option) {
-        String pref = NPCOptions.get(option).getInlinePrefix();
-        return pref != null ? pref : prefix.get(Config.getLanguage());
+    public String getPrefix(String lang, String option) {
+        String pref = NPCOptions.get(option).getInlinePrefix(lang);
+        if (pref == null) {
+            pref = NPCOptions.get(option).getInlinePrefix(Config.getLanguage());
+        }
+        // return inline prefix if defined
+        if (pref != null) return pref;
+        
+        // otherwise return global prefix
+        String global = prefix.get(lang);
+        if (global == null) {
+            global = prefix.get(Config.getLanguage());
+        }
+        return global;
     }
     
     /**
@@ -229,7 +242,7 @@ public class ConversationData {
     
     private interface Option {
         public String getName();
-        public abstract String getInlinePrefix();
+        public String getInlinePrefix(String lang);
         public String getText(String lang);
         public String[] getConditions();
         public String[] getEvents();
@@ -369,8 +382,12 @@ public class ConversationData {
             return name;
         }
         
-        public String getInlinePrefix() {
-            return inlinePrefix.get(Config.getLanguage());
+        public String getInlinePrefix(String lang) {
+            String thePrefix = inlinePrefix.get(lang);
+            if (thePrefix == null) {
+                thePrefix = inlinePrefix.get(Config.getLanguage());
+            }
+            return thePrefix;
         }
         
         public String getText(String lang) {
@@ -506,7 +523,7 @@ public class ConversationData {
             return name;
         }
         
-        public String getInlinePrefix() {
+        public String getInlinePrefix(String lang) {
             return null; // prefixes are only used with NPC options, not Player options
         }
         

--- a/src/main/resources/advanced-messages.yml
+++ b/src/main/resources/advanced-messages.yml
@@ -1,5 +1,5 @@
 pl:
-  conversation_start_named: '&2[&9{2}&2] &e====&bRozpocząłeś rozmowę z {1}!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bRozpocząłeś rozmowę z {1}!&e===='
   conversation_end: '&e====&bZakończyłeś rozmowę z {1}!&e===='
   help_with_answering: '&cAby odpowiedzieć NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
@@ -76,7 +76,7 @@ pl:
   cancel: '&cAnuluj zadanie'
   cancel_page: Anulowanie zadania
 en:
-  conversation_start_named: '&2[&9{2}&2] &e====&bConversation with {1} started!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
@@ -153,7 +153,7 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
-  conversation_start_named: '&2[&9{2}&2] &e====&bGespräch mit {1} begonnen!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bGespräch mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespräch mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
@@ -230,7 +230,7 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Mögliche Optionen: '
 fr:
-  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversation avec {1} est engagée!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bLa conversation avec {1} est engagée!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminée!&e===='
   help_with_answering: '&cRépondez au NPC en saisissant le numéro dans la console sans le point, ex. 2'
@@ -307,7 +307,7 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
-  conversation_start_named: '&2[&9{2}&2] &e====&b与{1}对话中&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&b与{1}对话中&e===='
   conversation_end: '&e====&b与{1}的对话已经结束&e===='
   help_with_answering: '&c请输入对话选项序号'
@@ -384,7 +384,7 @@ cn:
   language_missing: '&c请注明语言的名字'
   language_not_exist: '&c这个语言不存在，可用的语言有：'
 es:
-  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversacion con {1} ha comenzado.&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'

--- a/src/main/resources/advanced-messages.yml
+++ b/src/main/resources/advanced-messages.yml
@@ -1,5 +1,5 @@
 pl:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bRozpocząłeś rozmowę z {1}!&e===='
   conversation_end: '&e====&bZakończyłeś rozmowę z {1}!&e===='
   help_with_answering: '&cAby odpowiedzieć NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
@@ -76,7 +76,7 @@ pl:
   cancel: '&cAnuluj zadanie'
   cancel_page: Anulowanie zadania
 en:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
@@ -153,7 +153,7 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bGespräch mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespräch mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
@@ -230,7 +230,7 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Mögliche Optionen: '
 fr:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bLa conversation avec {1} est engagée!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminée!&e===='
   help_with_answering: '&cRépondez au NPC en saisissant le numéro dans la console sans le point, ex. 2'
@@ -307,7 +307,7 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&b与{1}对话中&e===='
   conversation_end: '&e====&b与{1}的对话已经结束&e===='
   help_with_answering: '&c请输入对话选项序号'
@@ -384,7 +384,7 @@ cn:
   language_missing: '&c请注明语言的名字'
   language_not_exist: '&c这个语言不存在，可用的语言有：'
 es:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'
@@ -461,7 +461,7 @@ es:
   language_missing: '&cEspecifica un lenguage'
   language_not_exist: '&cEste lenguage no esta definido, opciones posibles: '
 nl:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bGesprek met {1} begonnen!&e===='
   conversation_end: '&e====&bGesprek met {1} afgerond!&e===='
   help_with_answering: '&cGeef de NPC antwoord door een nummer van het antwoord te typen zonder een punt, bijv. 2'

--- a/src/main/resources/advanced-messages.yml
+++ b/src/main/resources/advanced-messages.yml
@@ -1,4 +1,5 @@
 pl:
+  conversation_start_named: '&2[&9{2}&2] &e====&bRozpocząłeś rozmowę z {1}!&e===='
   conversation_start: '&e====&bRozpocząłeś rozmowę z {1}!&e===='
   conversation_end: '&e====&bZakończyłeś rozmowę z {1}!&e===='
   help_with_answering: '&cAby odpowiedzieć NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
@@ -75,6 +76,7 @@ pl:
   cancel: '&cAnuluj zadanie'
   cancel_page: Anulowanie zadania
 en:
+  conversation_start_named: '&2[&9{2}&2] &e====&bConversation with {1} started!&e===='
   conversation_start: '&e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
@@ -151,6 +153,7 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
+  conversation_start_named: '&2[&9{2}&2] &e====&bGespräch mit {1} begonnen!&e===='
   conversation_start: '&e====&bGespräch mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespräch mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
@@ -227,6 +230,7 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Mögliche Optionen: '
 fr:
+  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversation avec {1} est engagée!&e===='
   conversation_start: '&e====&bLa conversation avec {1} est engagée!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminée!&e===='
   help_with_answering: '&cRépondez au NPC en saisissant le numéro dans la console sans le point, ex. 2'
@@ -303,6 +307,7 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
+  conversation_start_named: '&2[&9{2}&2] &e====&b与{1}对话中&e===='
   conversation_start: '&e====&b与{1}对话中&e===='
   conversation_end: '&e====&b与{1}的对话已经结束&e===='
   help_with_answering: '&c请输入对话选项序号'
@@ -379,6 +384,7 @@ cn:
   language_missing: '&c请注明语言的名字'
   language_not_exist: '&c这个语言不存在，可用的语言有：'
 es:
+  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'

--- a/src/main/resources/advanced-messages.yml
+++ b/src/main/resources/advanced-messages.yml
@@ -460,3 +460,80 @@ es:
   default_language_changed: '&2Lenguage por defecto cambiado!'
   language_missing: '&cEspecifica un lenguage'
   language_not_exist: '&cEste lenguage no esta definido, opciones posibles: '
+nl:
+  conversation_prefix: '&2[&9{1}&2]'
+  conversation_start: '&e====&bGesprek met {1} begonnen!&e===='
+  conversation_end: '&e====&bGesprek met {1} afgerond!&e===='
+  help_with_answering: '&cGeef de NPC antwoord door een nummer van het antwoord te typen zonder een punt, bijv. 2'
+  unknown_argument: '&cVerkeerd argument.'
+  no_permission: '&cJe hebt geen toestemming.'
+  reloaded: '&cConfiguratie is herladen!'
+  new_journal_entry: '&e*&bDagboek is bijgewerkt!&e*'
+  journal_title: Dagboek
+  journal_lore: Je dagboek, bevat alle quest informatie
+  quest_item: '&2Quest Item'
+  backpack_title: Rugzak
+  previous: '&2Vorige'
+  next: '&2Volgende'
+  inventory_full: '&e*&bJe inventaris is vol!&e*'
+  specify_condition: '&cSpecificeer conditie naam.'
+  specify_event: '&cSpecificeer gebeurtenis naam.'
+  specify_player: '&cSpecificeer speler''s naam.'
+  specify_item: '&cSpecificeer item''s naam.'
+  specify_tag: '&cSpecificeer label.'
+  specify_objective: '&cSpecificeer doelstelling naam.'
+  specify_category_and_amount: '&cSpecificeer categorie naam en aantal te bewerken punten.'
+  specify_pointer: '&cSpecificeer pointer naam.'
+  specify_date: '&cSpecificeer pointer datum (formaat zoals in date_format)'
+  specify_action: '&cSpecificeer actie (read, set of add)'
+  specify_path: '&cSpecificeer pad (gescheiden door punten)'
+  specify_package: '&cSpecificeer package naam'
+  package_created: '&2Package aangemaakt'
+  package_exists: '&cPackage bestaat al'
+  config_set_error: '&cKon opgegeven pad niet instellen.'
+  no_item: '&cJe hebt geen item in je hand!'
+  item_created: '&2Item opgeslagen in configuratie als {1}.'
+  player_objectives: '&aSpeler''s doelstellingen:'
+  player_tags: '&aSpeler''s labels:'
+  player_condition: '&aConditie {1}: {2}'
+  player_event: '&aGebeurtenis plaatsgevonden: {1}'
+  player_points: '&aSpeler''s punten:'
+  player_journal: '&ePointers in dagboek:'
+  points_added: '&2Punten toegevoegd!'
+  points_removed: '&2Punten afgetrokken!'
+  tag_added: '&2Label toegevoegd!'
+  tag_removed: '&2Label verwijderd!'
+  objective_added: '&2Doelstelling gestart!'
+  objective_removed: '&2Doelstelling gestopt!'
+  pointer_added: '&2Pointer toegevoegd!'
+  pointer_removed: '&2Pointer verwijderd!'
+  purged: '&4{1}''s data verwijderd!'
+  changelog: '&e*&bEr is een nieuw wijzigingslog beschikbaar in de plugin''s folder. Lees de wijzigingen en verwijder of hernoem het bestand om dit bericht te voorkomen!&e*'
+  command_reload: herlaad de plugin
+  command_objectives: actieve doelstellingen weergeven
+  command_tags: labels weergeven
+  command_points: punten weergeven
+  command_journal: dagboek pointers weergeven
+  command_condition: controleer of de speler aan de conditie voldoet
+  command_event: laat een gebeurtenis plaatsvinden voor de speler
+  command_item: maakt een item van hetgene in je hand
+  command_config: leest, stelt in of voegt toe aan strings in configuraties
+  command_vector: berekent een vector van eerste variabele en slaat op in tweede
+  command_purge: verwijdert alle data van de speler
+  command_backup: maakt configuratie en database backup. Gebruik alleen vanaf console wanneer iedereen is uitgelogd!
+  offline: '&4Alle spelers moeten uitgelogd zijn om een backup te maken!'
+  pullback: '&cRondt eerst je gesprek af!'
+  items_given: '&2Ontvangen {1} x{2}'
+  items_taken: '&2Afgegeven {1} x{2}'
+  blocks_to_break: '&2{1} blokken over om te breken'
+  blocks_to_place: '&2{1} blokken over om te plaatsen'
+  mobs_to_kill: '&2{1} monsters over om te doden'
+  busy: '&cJe kunt niet praten tijdens het vechten'
+  quest_canceled: '&2Quest {1} geannuleerd!'
+  cancel: '&cAnnuleer de quest'
+  cancel_page: Quests annuleren
+  command_blocked: '&cJe kunt dat commando niet gebruiken terwijl je in gesprek bent.'
+  language_changed: '&2Taal gewijzigd!'
+  default_language_changed: '&2Standaard taal gewijzigd!'
+  language_missing: '&cSpecificeer taal'
+  language_not_exist: '&cDeze taal is niet gedefinieerd, mogelijke opties: '

--- a/src/main/resources/defaultConversation.yml
+++ b/src/main/resources/defaultConversation.yml
@@ -5,6 +5,7 @@ quester:
   fr: 'Aubergiste'
   cn: "\u65c5\u9986\u8001\u677f"
   de: 'Gastwirt'
+  nl: 'Herbergier'
 first: 'start,start_wood_started,start_wood_completed'
 stop: 'false'
 NPC_options:
@@ -16,6 +17,7 @@ NPC_options:
       fr: 'Bienvenue dans mon auberge %player%! Que puis-je faire pour votre service?'
       cn: "\u6b22\u8fce\u6765\u5230\u6211\u7684\u65c5\u5e97\uff0c%player%! \u6709\u4ec0\u4e48\u6211\u53ef\u4ee5\u5e2e\u4f60\u7684\u5417\uff1f"
       de: 'Willkommen in meinem Gasthaus, %player%! Was kann ich fuer dich tun?'
+      nl: 'Welkom in mijn herberg, %player%! Wat kan ik voor je doen?'
     conditions: '!wood_started'
     pointer: 'questions,quests,bye'
   'back':
@@ -26,6 +28,7 @@ NPC_options:
       fr: 'Oui?'
       cn: "\u6069\uff1f"
       de: 'Ja?'
+      nl: 'Ja?'
     pointer: 'questions,quests,wood_questions,wood_done,more_quests,bye'
   'start_wood_started':
     text:
@@ -35,6 +38,7 @@ NPC_options:
       fr: 'Deja de retour! Vous avez trouve du bois?'
       cn: "\u6b22\u8fce\u56de\u6765\uff01\u5173\u4e8e\u4f10\u6728\u7684\u4e8b\u60c5\u505a\u5f97\u600e\u6837\u4e86\uff1f"
       de: 'Willkommen zurueck! Wie laeuft es mit dem Holz?'
+      nl: 'Welkom terug! Hoe gaat het met dat hout?'
     conditions: 'wood_started,!wood_paid'
     pointer: 'questions,wood_questions,wood_done,bye'
   'start_wood_completed':
@@ -45,6 +49,7 @@ NPC_options:
       fr: 'Ah, mon client prefere! Que souhaitez-vous?'
       cn: "\u554a\uff0c\u4eb2\u7231\u7684\u5ba2\u5b98\uff0c\u6709\u4ec0\u4e48\u6211\u53ef\u4ee5\u5e2e\u7684\u4e48\uff1f"
       de: 'Ah, mein Lieblingskunde! Wie kann ich dir helfen?'
+      nl: 'Ah, mijn favoriete klant! Hoe kan ik je helpen?'
     conditions: 'wood_paid'
     pointer: 'questions,more_quests,bye'
   'quest_wood':
@@ -55,6 +60,7 @@ NPC_options:
       fr: 'Je fabriquais de nouvelles chopes de biere mais je manque de bois. Il y a une foret a cote vous pourriez m''en rapporter?'
       cn: "\u6211\u6b63\u5728\u505a\u4e00\u4e9b\u9152\u676f\uff0c\u4f46\u662f\u53d1\u73b0\u6211\u6ca1\u6709\u6728\u5934\u4e86\u3002\u4f60\u53ef\u4ee5\u4ece\u9644\u8fd1\u7684\u68ee\u6797\u4e2d\u5f04\u4e00\u4e9b\u6765\u7ed9\u6211\u4e48\uff1f"
       de: 'Ich wollte gerade neue Bierkruege herstellen, aber ich habe kein Holz mehr. Kannst du mir welches aus dem nahen Wald holen?'
+      nl: 'Ik was nieuwe mokken voor bier aan het maken, maar ik heb geen hout meer. Kun je me wat van het dichtbij gelegen bos halen?'
     pointer: 'wood_yes,wood_no'
   'questions':
     text:
@@ -64,6 +70,7 @@ NPC_options:
       fr: 'Je vais essayer de vous repondre au mieux.'
       cn: "\u6211\u4f1a\u5c3d\u529b\u56de\u7b54\u4f60\u7684\u95ee\u9898"
       de: 'Ich werde so gut es geht antworten.'
+      nl: 'Ik zal zo goed mogelijk antwoorden.'
     pointer: 'wood_where,wood_how,wood_with_what,no_questions'
   'wood_reward':
     text:
@@ -73,6 +80,7 @@ NPC_options:
       fr: 'Excelent! Voici 5 emeraudes pour voous!'
       cn: "\u592a\u597d\u4e86\uff0c\u8c22\u8c22\u4f60\uff01\u8fd9\u91cc\u662f\u4f60\u7684\u62a5\u916c\uff0c\u4e94\u4e2a\u7eff\u5b9d\u77f3\u3002"
       de: 'Hervorragend! Hier hast du 5 Smaragde!'
+      nl: 'Uitstekend! Hier zijn 5 smaragden voor jou!'
     conditions: 'has_wood'
     events: 'wood_reward,remove_wood,tag_wood_paid,entry_wood_paid'
     pointer: 'questions,more_quests,bye'
@@ -84,6 +92,7 @@ NPC_options:
       fr: 'Ou cela? Je ne trouve rien dans votre inventaire...'
       cn: "\u4f46\u662f\u4f60\u4f3c\u4e4e\u5e76\u6ca1\u6709\u6728\u5934\u7ed9\u6211\u554a\u2026\u2026"
       de: 'Wo? Ich sehe nichts in deinem Inventar...'
+      nl: 'Waar? Ik zie niets in je inventaris...'
     conditions: '!has_wood'
     pointer: 'now,wood_go,questions'
   'no_quests':
@@ -94,6 +103,7 @@ NPC_options:
       fr: 'Malheureusement je n''ai plus rien en ce moment. Revenez un peu plus tard'
       cn: "\u62b1\u6b49\uff0c\u6211\u73b0\u5728\u6ca1\u4ec0\u4e48\u4e8b\u60c5\u53ef\u4ee5\u7ed9\u4f60\u505a\uff0c\u665a\u4e9b\u518d\u6765\u5427\u3002"
       de: 'Leider habe ich zur Zeit keine weiteren Aufgaben. Schau spaeter noch mal vorbei.'
+      nl: 'Helaas heb ik niets anders. Kom later nog eens terug.'
     pointer: 'questions,bye'
   'wood_yes':
     text:
@@ -103,6 +113,7 @@ NPC_options:
       fr: 'Super. Allez dans la foret et ramenez moi un peu de bois.'
       cn: "\u592a\u597d\u4e86\uff0c\u5feb\u53bb\u68ee\u6797\u7ed9\u6211\u5f04\u4e00\u4e9b\u6728\u5934\u5427"
       de: 'Sehr gut. Geh in den Wald und bring mit etwas Holz.'
+      nl: 'Fantastisch. Ga naar het bos en breng me wat hout.'
     pointer: 'wood_go,wood_questions,back'
   'wood_no':
     text:
@@ -112,6 +123,7 @@ NPC_options:
       fr: 'Dommage.'
       cn: "\u554a\u2026\u2026\u662f\u5417"
       de: 'Sehr schade.'
+      nl: 'Dat is jammer.'
   'wood_where':
     text:
       en: 'Go out of the village through south gate and turn left. There is a forest.'
@@ -120,6 +132,7 @@ NPC_options:
       fr: 'En sortant du village et en prenant a gauche vous verrez. Il y a une foret.'
       cn: "\u4ece\u6751\u5b50\u5357\u95e8\u51fa\u53bb\u5de6\u8f6c\uff0c\u90a3\u8fb9\u5c31\u6709\u4e2a\u68ee\u6797"
       de: 'Verlasse das Dorf durch das Suedtor und geh nach links. Dann kommst du zum Wald.'
+      nl: 'Verlaat het dorp via de zuidpoort en ga linksaf. Daar is het bos.'
     pointer: 'wood_how,wood_with_what,no_questions'
   'wood_how':
     text:
@@ -129,6 +142,7 @@ NPC_options:
       fr: 'Il suffit de se placer face a un arbre et de le taper jusqu''a ce que des blocs tombent. C''est tres facile.'
       cn: "\u7ad9\u5728\u6811\u7684\u524d\u9762\uff0c\u62fc\u547d\u63cd\u5b83\uff0c\u76f4\u5230\u4e00\u4e2a\u6728\u5934\u4ece\u5929\u4e0a\u6389\u4e0b\u6765\u2014\u2014\u8fd9\u4f60\u90fd\u4e0d\u4f1a\uff1f"
       de: 'Stell dich vor einen Baum und schlage ihn, bis ein Holzblock herauskommt. So einfach ist es.'
+      nl: 'Ga voor de boom staan en begin het te stompen totdat er een blok hout uitkomt. Zo eenvoudig is het.'
     pointer: 'wood_where,wood_with_what,no_questions'
   'wood_with_what':
     text:
@@ -138,6 +152,7 @@ NPC_options:
       fr: 'Vous pouvez aller dans la cabane de luberjack. Je pense que vous trouverez des haches la bas cela sera plus facile.'
       cn: "\u4f60\u53ef\u4ee5\u53bb\u4f10\u6728\u4eba\u7684\u5c0f\u5c4b\u770b\u770b\uff0c\u8bf4\u4e0d\u5b9a\u80fd\u627e\u5230\u4e00\u4e2a\u65a7\u5934\u5462"
       de: 'Schau mal in der Holzfaellerhuette. Ich bin mir sicher, dass du dort ein paar Aexte finden wirst.'
+      nl: 'Kijk eens in de hut van de houthakker. Ik weet zeker dat je daar een paar bijlen kunt vinden.'
     pointer: 'wood_where,wood_how,no_questions'
   'no_questions':
     text:
@@ -147,6 +162,7 @@ NPC_options:
       fr: 'J''espere vous avoir aide.'
       cn: "\u6211\u5e0c\u671b\u6211\u5e2e\u5230\u4e86\u4f60"
       de: 'Ich hoffe, ich konnte helfen.'
+      nl: 'Ik hoop dat ik je geholpen heb.'
     pointer: 'wood_go,back'
   'wood_go':
     text:
@@ -156,6 +172,7 @@ NPC_options:
       fr: 'Bonne chance!'
       cn: "\u795d\u4f60\u4e00\u8def\u987a\u98ce\uff01"
       de: 'Viel Glueck!'
+      nl: 'Succes!'
 player_options:
   'questions':
     text:
@@ -165,6 +182,7 @@ player_options:
       fr: 'J''ai des questions.'
       cn: "\u6211\u60f3\u95ee\u51e0\u4e2a\u95ee\u9898"
       de: 'Ich habe Fragen.'
+      nl: 'Ik wou wat vragen.'
   'back':
     text:
       en: 'Back to the topic...'
@@ -173,6 +191,7 @@ player_options:
       fr: 'Retour au menu...'
       cn: "\u8bdd\u8bf4\u56de\u6765\u2026\u2026"
       de: 'Zurueck zum Inhalt...'
+      nl: 'Terug naar het onderwerp...'
     pointer: 'back'
   'quests':
     text:
@@ -182,6 +201,7 @@ player_options:
       fr: 'Auriez-vous des quetes ? J''ai besoin d''argent.'
       cn: "\u4f60\u6709\u4ec0\u4e48\u9700\u8981\u5e2e\u5fd9\u7684\u4e48\uff1f\u6211\u9700\u8981\u94b1"
       de: 'Hast du Aufgaben fuer mich? Ich brauche Geld.'
+      nl: 'Heb je misschien wat quests voor mij? Ik heb geld nodig.'
     conditions: '!wood_started'
     pointer: 'quest_wood'
   'wood_questions':
@@ -192,6 +212,7 @@ player_options:
       fr: 'Je me pose des questions pour couper les arbres.'
       cn: "\u6211\u60f3\u95ee\u4e00\u4e0b\u5173\u4e8e\u4f10\u6728\u7684\u95ee\u9898"
       de: 'Ich habe ein paar Fragen zum Holzfaellen.'
+      nl: 'Ik heb wat vragen over dit houthakken.'
     conditions: 'wood_started,!wood_paid'
     pointer: 'questions'
   'wood_done':
@@ -202,6 +223,7 @@ player_options:
       fr: 'J''ai votre bois.'
       cn: "\u6211\u5df2\u7ecf\u62ff\u5230\u4e86\u4f60\u8981\u7684\u6728\u5934"
       de: 'Ich hab das ganze Holz geholt.'
+      nl: 'Ik heb al het hout verzameld.'
     conditions: 'wood_done,has_wood,!wood_paid'
     pointer: 'wood_reward,wood_doesnt_have'
   'more_quests':
@@ -212,6 +234,7 @@ player_options:
       fr: 'Auriez-vous d''autres quetes?'
       cn: "\u8fd8\u6709\u4ec0\u4e48\u522b\u7684\u6211\u53ef\u4ee5\u5e2e\u4f60\u7684\u4e48\uff1f"
       de: 'Hast du noch andere Aufgaben fuer mich?'
+      nl: 'Heb je misschien nog andere quests?'
     conditions: 'wood_paid'
     pointer: 'no_quests'
   'wood_yes':
@@ -222,6 +245,7 @@ player_options:
       fr: 'Cela me semble bien.'
       cn: "\u542c\u8d77\u6765\u4e0d\u9519"
       de: 'Klingt gut.'
+      nl: 'Klinkt goed.'
     events: 'wood_start,tag_wood_started,entry_wood_started'
     pointer: 'wood_yes'
   'wood_no':
@@ -232,6 +256,7 @@ player_options:
       fr: 'D''un autre cote je n''ai pas vraiment besoin de cet argent.'
       cn: "\u6069\u2026\u2026\u6211\u4e0d\u9700\u8981\u90a3\u4e2a"
       de: 'Mh, andererseits brauche ich das Geld doch nicht so dringend.'
+      nl: 'Bij nader inzien, heb ik dat geld toch niet nodig.'
     pointer: 'wood_no'
   'wood_where':
     text:
@@ -241,6 +266,7 @@ player_options:
       fr: 'Ou se trouve cette foret?'
       cn: "\u68ee\u6797\u5728\u54ea\uff1f"
       de: 'Wo ist der Wald?'
+      nl: 'Waar is het bos?'
     pointer: 'wood_where'
   'wood_how':
     text:
@@ -250,6 +276,7 @@ player_options:
       fr: 'Comment puis-je ramasser du bois ?'
       cn: "\u6211\u600e\u4e48\u624d\u80fd\u780d\u6728\u5934\uff1f"
       de: 'Wie kann ich Holz faellen?'
+      nl: 'Hoe kan ik hout hakken?'
     pointer: 'wood_how'
   'wood_with_what':
     text:
@@ -259,6 +286,7 @@ player_options:
       fr: 'Avec quoi tailler le bois ?'
       cn: "\u6211\u8981\u7528\u4ec0\u4e48\u4f10\u6728\uff1f"
       de: 'Womit kann ich Holz faellen?'
+      nl: 'Waarmee kan ik hout hakken?'
     pointer: 'wood_with_what'
   'no_questions':
     text:
@@ -268,6 +296,7 @@ player_options:
       fr: 'Je n''ai plus de question'
       cn: "\u6211\u6ca1\u6709\u8981\u95ee\u7684\u4e1c\u897f\u4e86"
       de: 'Ich habe keine Fragen.'
+      nl: 'Ik heb geen vragen.'
     pointer: 'no_questions'
   'wood_go':
     text:
@@ -277,6 +306,7 @@ player_options:
       fr: 'Ok, je vais tailler les arbres.'
       cn: "\u597d\uff0c\u6211\u8fd9\u5c31\u53bb\u4f10\u6728"
       de: 'Ok, dann gehe ich mal ein paar Baeume faellen.'
+      nl: 'Ok, dan ga ik maar een paar bomen omhakken.'
     pointer: 'wood_go'
   'now':
     text:
@@ -286,6 +316,7 @@ player_options:
       fr: 'Et maintenant ?'
       cn: "\u73b0\u5728\u5462\uff1f"
       de: 'Wie ist es jetzt?'
+      nl: 'En nu?'
     pointer: 'wood_reward,wood_doesnt_have'
   'bye':
     text:
@@ -295,3 +326,4 @@ player_options:
       fr: 'Au revoir.'
       cn: "\u518d\u89c1"
       de: 'Auf bald.'
+      nl: 'Tot ziens.'

--- a/src/main/resources/journal.yml
+++ b/src/main/resources/journal.yml
@@ -5,6 +5,7 @@ wood_started:
   fr: 'L''aubergiste me demande de rapporter 16 blocs de bois de la foret voisine.'
   cn: "\u65c5\u5e97\u8001\u677f\u8ba9\u6211\u53bb\u65c1\u8fb9\u7684\u68ee\u6797\u7ed9\u4ed6\u5f0416\u5757\u6728\u5934"
   de: 'Der Gastwirt bat mich, ihm 16 Holzbloecke aus dem nahen Wald zu holen.'
+  nl: 'De herbergier vroeg me 16 blokken hout te verzamelen van een dichtbij gelegen bos.'
 wood_done:
   en: 'I colected 16 block of wood. I should return to the Innkeeper.'
   es: 'He recolectado los 16 bloques de madera. Deberia volver con el Tabernero.'
@@ -12,6 +13,7 @@ wood_done:
   fr: 'J''ai obtenu les 16 blocs de bois, je dois retourner voir l''aubergiste.'
   cn: "\u6211\u5df2\u7ecf\u5f04\u5230\u4e8616\u5757\u6728\u5934\uff0c\u73b0\u5728\u5e94\u8be5\u53ef\u4ee5\u56de\u53bb\u627e\u65c5\u5e97\u8001\u677f\u4e86"
   de: 'Ich habe die 16 Holzbloecke zusammen. Ich sollte wieder zurueck zum Gastwirt.'
+  nl: 'Ik heb 16 blokken hout verzameld. Ik moet terug naar de herbergier.'
 wood_paid:
   en: 'I brought wood to the Innkeeper and he gave me 5 emeralds.'
   es: 'He traido la madera al Tabernero y me ha dado 5 esmeraldas.'
@@ -19,3 +21,4 @@ wood_paid:
   fr: 'J''ai ramene les blocs de bois et l''aubergiste m''a donne 5 emeraudes.'
   cn: "\u6211\u5c0616\u5757\u6728\u5934\u7ed9\u4e86\u65c5\u5e97\u8001\u677f\uff0c\u4ed6\u7ed9\u4e86\u62115\u4e2a\u7eff\u5b9d\u77f3"
   de: 'Ich habe das Holz beim Gastwirt abgeliefert und dafuer 5 Smaragde von ihm bekommen.'
+  nl: 'Ik heb hout gebracht naar de herbergier, en die gaf me daarvoor 5 smaragden.'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,5 +1,5 @@
 pl:
-  conversation_start: '&e====&bRozpoczales rozmowe z {1}!&e===='
+  conversation_start: '&2[&9{2}&2] &e====&bRozpoczales rozmowe z {1}!&e===='
   conversation_end: '&e====&bZakonczyles rozmowe z {1}!&e===='
   help_with_answering: '&cAby odpowiedziec NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
   unknown_argument: '&cNiewlasciwy argument.'
@@ -75,7 +75,7 @@ pl:
   language_missing: '&cPodaj jezyk'
   language_not_exist: '&cTen jezyk nie jest zdefiniowany, oto lista dostepnych opcji: '
 en:
-  conversation_start: '&e====&bConversation with {1} started!&e===='
+  conversation_start: '&2[&9{2}&2] &e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
   unknown_argument: '&cWrong argument.'
@@ -151,7 +151,7 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
-  conversation_start: '&e====&bGespraech mit {1} begonnen!&e===='
+  conversation_start: '&2[&9{2}&2] &e====&bGespraech mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespraech mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
   unknown_argument: '&cFalsches Argument festgestellt.'
@@ -227,7 +227,7 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Moegliche Optionen: '
 fr:
-  conversation_start: '&e====&bLa conversation avec {1} est engagee!&e===='
+  conversation_start: '&2[&9{2}&2] &e====&bLa conversation avec {1} est engagee!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminee!&e===='
   help_with_answering: '&cRepondez au NPC en saisissant le numero dans la console sans le point, ex. 2'
   unknown_argument: '&cMauvais parametre.'
@@ -303,7 +303,7 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
-  conversation_start: "&e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
+  conversation_start: "&2[&9{2}&2] &e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
   conversation_end: "&e====&b\u4e0e{1}\u7684\u5bf9\u8bdd\u5df2\u7ecf\u7ed3\u675f&e===="
   help_with_answering: "&c\u8bf7\u8f93\u5165\u5bf9\u8bdd\u9009\u9879\u5e8f\u53f7"
   unknown_argument: "&c\u672a\u77e5\u7684\u547d\u4ee4\uff0c\u8bf7\u8f93\u5165/q\u67e5\u770b\u547d\u4ee4\u5217\u8868"
@@ -379,7 +379,7 @@ cn:
   language_missing: "&c\u8bf7\u6ce8\u660e\u8bed\u8a00\u7684\u540d\u5b57"
   language_not_exist: "&c\u8fd9\u4e2a\u8bed\u8a00\u4e0d\u5b58\u5728\uff0c\u53ef\u7528\u7684\u8bed\u8a00\u6709\uff1a"
 es:
-  conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
+  conversation_start: '&2[&9{2}&2] &e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'
   unknown_argument: '&cArgumento incorrecto.'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,5 +1,6 @@
 pl:
-  conversation_start: '&2[&9{2}&2] &e====&bRozpoczales rozmowe z {1}!&e===='
+  conversation_start_named: '&2[&9{2}&2] &e====&bRozpoczales rozmowe z {1}!&e===='
+  conversation_start: '&e====&bRozpoczales rozmowe z {1}!&e===='
   conversation_end: '&e====&bZakonczyles rozmowe z {1}!&e===='
   help_with_answering: '&cAby odpowiedziec NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
   unknown_argument: '&cNiewlasciwy argument.'
@@ -75,7 +76,8 @@ pl:
   language_missing: '&cPodaj jezyk'
   language_not_exist: '&cTen jezyk nie jest zdefiniowany, oto lista dostepnych opcji: '
 en:
-  conversation_start: '&2[&9{2}&2] &e====&bConversation with {1} started!&e===='
+  conversation_start_named: '&2[&9{2}&2] &e====&bConversation with {1} started!&e===='
+  conversation_start: '&e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
   unknown_argument: '&cWrong argument.'
@@ -151,7 +153,8 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
-  conversation_start: '&2[&9{2}&2] &e====&bGespraech mit {1} begonnen!&e===='
+  conversation_start_named: '&2[&9{2}&2] &e====&bGespraech mit {1} begonnen!&e===='
+  conversation_start: '&e====&bGespraech mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespraech mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
   unknown_argument: '&cFalsches Argument festgestellt.'
@@ -227,7 +230,8 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Moegliche Optionen: '
 fr:
-  conversation_start: '&2[&9{2}&2] &e====&bLa conversation avec {1} est engagee!&e===='
+  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversation avec {1} est engagee!&e===='
+  conversation_start: '&e====&bLa conversation avec {1} est engagee!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminee!&e===='
   help_with_answering: '&cRepondez au NPC en saisissant le numero dans la console sans le point, ex. 2'
   unknown_argument: '&cMauvais parametre.'
@@ -303,7 +307,8 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
-  conversation_start: "&2[&9{2}&2] &e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
+  conversation_start_named: "&2[&9{2}&2] &e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
+  conversation_start: "&e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
   conversation_end: "&e====&b\u4e0e{1}\u7684\u5bf9\u8bdd\u5df2\u7ecf\u7ed3\u675f&e===="
   help_with_answering: "&c\u8bf7\u8f93\u5165\u5bf9\u8bdd\u9009\u9879\u5e8f\u53f7"
   unknown_argument: "&c\u672a\u77e5\u7684\u547d\u4ee4\uff0c\u8bf7\u8f93\u5165/q\u67e5\u770b\u547d\u4ee4\u5217\u8868"
@@ -379,7 +384,8 @@ cn:
   language_missing: "&c\u8bf7\u6ce8\u660e\u8bed\u8a00\u7684\u540d\u5b57"
   language_not_exist: "&c\u8fd9\u4e2a\u8bed\u8a00\u4e0d\u5b58\u5728\uff0c\u53ef\u7528\u7684\u8bed\u8a00\u6709\uff1a"
 es:
-  conversation_start: '&2[&9{2}&2] &e====&bLa conversacion con {1} ha comenzado.&e===='
+  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversacion con {1} ha comenzado.&e===='
+  conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'
   unknown_argument: '&cArgumento incorrecto.'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,5 +1,5 @@
 pl:
-  conversation_start_named: '&2[&9{2}&2] &e====&bRozpoczales rozmowe z {1}!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bRozpoczales rozmowe z {1}!&e===='
   conversation_end: '&e====&bZakonczyles rozmowe z {1}!&e===='
   help_with_answering: '&cAby odpowiedziec NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
@@ -76,7 +76,7 @@ pl:
   language_missing: '&cPodaj jezyk'
   language_not_exist: '&cTen jezyk nie jest zdefiniowany, oto lista dostepnych opcji: '
 en:
-  conversation_start_named: '&2[&9{2}&2] &e====&bConversation with {1} started!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
@@ -153,7 +153,7 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
-  conversation_start_named: '&2[&9{2}&2] &e====&bGespraech mit {1} begonnen!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bGespraech mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespraech mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
@@ -230,7 +230,7 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Moegliche Optionen: '
 fr:
-  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversation avec {1} est engagee!&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bLa conversation avec {1} est engagee!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminee!&e===='
   help_with_answering: '&cRepondez au NPC en saisissant le numero dans la console sans le point, ex. 2'
@@ -307,7 +307,7 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
-  conversation_start_named: "&2[&9{2}&2] &e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
+  conversation_prefix: "&2[&9{1}&2]"
   conversation_start: "&e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
   conversation_end: "&e====&b\u4e0e{1}\u7684\u5bf9\u8bdd\u5df2\u7ecf\u7ed3\u675f&e===="
   help_with_answering: "&c\u8bf7\u8f93\u5165\u5bf9\u8bdd\u9009\u9879\u5e8f\u53f7"
@@ -384,7 +384,7 @@ cn:
   language_missing: "&c\u8bf7\u6ce8\u660e\u8bed\u8a00\u7684\u540d\u5b57"
   language_not_exist: "&c\u8fd9\u4e2a\u8bed\u8a00\u4e0d\u5b58\u5728\uff0c\u53ef\u7528\u7684\u8bed\u8a00\u6709\uff1a"
 es:
-  conversation_start_named: '&2[&9{2}&2] &e====&bLa conversacion con {1} ha comenzado.&e===='
+  conversation_prefix: '&2[&9{1}&2]'
   conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,5 +1,5 @@
 pl:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bRozpoczales rozmowe z {1}!&e===='
   conversation_end: '&e====&bZakonczyles rozmowe z {1}!&e===='
   help_with_answering: '&cAby odpowiedziec NPCowi napisz na chacie numer wybranej odpowiedzi bez kropki, np. 2'
@@ -76,7 +76,7 @@ pl:
   language_missing: '&cPodaj jezyk'
   language_not_exist: '&cTen jezyk nie jest zdefiniowany, oto lista dostepnych opcji: '
 en:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bConversation with {1} started!&e===='
   conversation_end: '&e====&bConversation with {1} finished!&e===='
   help_with_answering: '&cAnswer the NPC by typing a number of the answer without a dot, eg. 2'
@@ -153,7 +153,7 @@ en:
   language_missing: '&cSpecify language'
   language_not_exist: '&cThis language is not defined, possible options: '
 de:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bGespraech mit {1} begonnen!&e===='
   conversation_end: '&e====&bGespraech mit {1} beendet!&e===='
   help_with_answering: '&cAntworte dem NPC, indem du die Zahl der Zeile ohne "." eintippst (z.B. 2)'
@@ -230,7 +230,7 @@ de:
   language_missing: '&cBitte eine Sprache angeben.'
   language_not_exist: '&cDiese Sprache ist nicht definiert. Moegliche Optionen: '
 fr:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bLa conversation avec {1} est engagee!&e===='
   conversation_end: '&e====&bLa conversation avec {1} est terminee!&e===='
   help_with_answering: '&cRepondez au NPC en saisissant le numero dans la console sans le point, ex. 2'
@@ -307,7 +307,7 @@ fr:
   language_missing: '&cChoix de la langue'
   language_not_exist: '&cCette langue n''est pas disponible, choix possibles: '
 cn:
-  conversation_prefix: "&2[&9{1}&2]"
+  conversation_prefix: "&2[&9{1}&2] "
   conversation_start: "&e====&b\u4e0e{1}\u5bf9\u8bdd\u4e2d&e===="
   conversation_end: "&e====&b\u4e0e{1}\u7684\u5bf9\u8bdd\u5df2\u7ecf\u7ed3\u675f&e===="
   help_with_answering: "&c\u8bf7\u8f93\u5165\u5bf9\u8bdd\u9009\u9879\u5e8f\u53f7"
@@ -384,7 +384,7 @@ cn:
   language_missing: "&c\u8bf7\u6ce8\u660e\u8bed\u8a00\u7684\u540d\u5b57"
   language_not_exist: "&c\u8fd9\u4e2a\u8bed\u8a00\u4e0d\u5b58\u5728\uff0c\u53ef\u7528\u7684\u8bed\u8a00\u6709\uff1a"
 es:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bLa conversacion con {1} ha comenzado.&e===='
   conversation_end: '&e====&bLa conversacion con {1} ha terminado.&e===='
   help_with_answering: '&cResponde al personaje escribiendo el numero de la respuesta, ej: 2.'
@@ -461,7 +461,7 @@ es:
   language_missing: '&cEspecifica un lenguage'
   language_not_exist: '&cEste lenguage no esta definido, opciones posibles: '
 nl:
-  conversation_prefix: '&2[&9{1}&2]'
+  conversation_prefix: '&2[&9{1}&2] '
   conversation_start: '&e====&bGesprek met {1} begonnen!&e===='
   conversation_end: '&e====&bGesprek met {1} afgerond!&e===='
   help_with_answering: '&cGeef de NPC antwoord door een nummer van het antwoord te typen zonder een punt, bijv. 2'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -460,3 +460,81 @@ es:
   default_language_changed: '&2Lenguage por defecto cambiado!'
   language_missing: '&cEspecifica un lenguage'
   language_not_exist: '&cEste lenguage no esta definido, opciones posibles: '
+nl:
+  conversation_prefix: '&2[&9{1}&2]'
+  conversation_start: '&e====&bGesprek met {1} begonnen!&e===='
+  conversation_end: '&e====&bGesprek met {1} afgerond!&e===='
+  help_with_answering: '&cGeef de NPC antwoord door een nummer van het antwoord te typen zonder een punt, bijv. 2'
+  unknown_argument: '&cVerkeerd argument.'
+  no_permission: '&cJe hebt geen toestemming.'
+  reloaded: '&cConfiguratie is herladen!'
+  new_journal_entry: '&e*&bDagboek is bijgewerkt!&e*'
+  journal_title: Dagboek
+  journal_lore: Je dagboek, bevat alle quest informatie
+  quest_item: '&2Quest Item'
+  backpack_title: Rugzak
+  previous: '&2Vorige'
+  next: '&2Volgende'
+  inventory_full: '&e*&bJe inventaris is vol!&e*'
+  specify_condition: '&cSpecificeer conditie naam.'
+  specify_event: '&cSpecificeer gebeurtenis naam.'
+  specify_player: '&cSpecificeer speler''s naam.'
+  specify_item: '&cSpecificeer item''s naam.'
+  specify_tag: '&cSpecificeer label.'
+  specify_objective: '&cSpecificeer doelstelling naam.'
+  specify_category_and_amount: '&cSpecificeer categorie naam en aantal te bewerken punten.'
+  specify_pointer: '&cSpecificeer pointer naam.'
+  specify_date: '&cSpecificeer pointer datum (formaat zoals in date_format)'
+  specify_action: '&cSpecificeer actie (read, set of add)'
+  specify_path: '&cSpecificeer pad (gescheiden door punten)'
+  specify_package: '&cSpecificeer package naam'
+  package_created: '&2Package aangemaakt'
+  package_exists: '&cPackage bestaat al'
+  config_set_error: '&cKon opgegeven pad niet instellen.'
+  no_item: '&cJe hebt geen item in je hand!'
+  item_created: '&2Item opgeslagen in configuratie als {1}.'
+  player_objectives: '&aSpeler''s doelstellingen:'
+  player_tags: '&aSpeler''s labels:'
+  player_condition: '&aConditie {1}: {2}'
+  player_event: '&aGebeurtenis plaatsgevonden: {1}'
+  player_points: '&aSpeler''s punten:'
+  player_journal: '&ePointers in dagboek:'
+  points_added: '&2Punten toegevoegd!'
+  points_removed: '&2Punten afgetrokken!'
+  tag_added: '&2Label toegevoegd!'
+  tag_removed: '&2Label verwijderd!'
+  objective_added: '&2Doelstelling gestart!'
+  objective_removed: '&2Doelstelling gestopt!'
+  pointer_added: '&2Pointer toegevoegd!'
+  pointer_removed: '&2Pointer verwijderd!'
+  purged: '&4{1}''s data verwijderd!'
+  changelog: '&e*&bEr is een nieuw wijzigingslog beschikbaar in de plugin''s folder. Lees de wijzigingen en verwijder of hernoem het bestand om dit bericht te voorkomen!&e*'
+  command_reload: herlaad de plugin
+  command_objectives: actieve doelstellingen weergeven
+  command_tags: labels weergeven
+  command_points: punten weergeven
+  command_journal: dagboek pointers weergeven
+  command_condition: controleer of de speler aan de conditie voldoet
+  command_event: laat een gebeurtenis plaatsvinden voor de speler
+  command_item: maakt een item van hetgene in je hand
+  command_config: leest, stelt in of voegt toe aan strings in configuraties
+  command_vector: berekent een vector van eerste variabele en slaat op in tweede
+  command_purge: verwijdert alle data van de speler
+  command_backup: maakt configuratie en database backup. Gebruik alleen vanaf console wanneer iedereen is uitgelogd!
+  offline: '&4Alle spelers moeten uitgelogd zijn om een backup te maken!'
+  pullback: '&cRondt eerst je gesprek af!'
+  items_given: '&2Ontvangen {1} x{2}'
+  items_taken: '&2Afgegeven {1} x{2}'
+  blocks_to_break: '&2{1} blokken over om te breken'
+  blocks_to_place: '&2{1} blokken over om te plaatsen'
+  mobs_to_kill: '&2{1} monsters over om te doden'
+  busy: '&cJe kunt niet praten tijdens het vechten'
+  quest_canceled: '&2Quest {1} geannuleerd!'
+  cancel: '&cAnnuleer de quest'
+  cancel_page: Quests annuleren
+  command_blocked: '&cJe kunt dat commando niet gebruiken terwijl je in gesprek bent.'
+  language_changed: '&2Taal gewijzigd!'
+  default_language_changed: '&2Standaard taal gewijzigd!'
+  language_missing: '&cSpecificeer taal'
+  language_not_exist: '&cDeze taal is niet gedefinieerd, mogelijke opties: '
+  


### PR DESCRIPTION
Disclaimer: This is my first fork, and my first github repo. I studied everything and hope I'm doing this correctly. But if not, please tell me why and how and I will try my best.

This fork adds a feature to BetonQuest to show the related questname when a conversation starts.
When no questname is specified yet for a conversation, like in existing installments, behavior is unchanged.

Normally when a conversation starts, it shows the conversation_start message. But if that conversation specifies a questname, it will "prepend" that name as a tag in front of it. Technically it's a separate message for customizability.

This name can be either globally specified for the whole conversation, for individual (starting) NPC_options or both. If both global and option specify a name, the option one overrides the global one. This can be flexibly used to differentiate different conversations with the same NPC for more than one quest, and tell the player in what quest they are speaking in.

I've added more details about the mechanic in the commit messages, most notably the first.
Lastly, I'd like to mention this is merely support, everything is optional and existing BetonQuest users are not affected if they don't update their conversation configs.