### PR TITLE
Fix permission for CitizensNPC

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensListener.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensListener.java
@@ -48,6 +48,9 @@ public class CitizensListener implements Listener {
 		if (event.isCancelled()) {
 			return;
 		}
+		if (!event.getClicker().hasPermission("betonquest.conversation")) {
+			return;
+		}
 		if (NPCMoveEvent.isNPCMoving(event.getNPC())) {
 			return;
 		}


### PR DESCRIPTION
Fix player without "betonquest.conversation" permission node, still could have conversation with Citizens NPC.