### PR TITLE
PlayerInteractEvent should only fired for the mainhand

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/conversation/CubeNPCListener.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/CubeNPCListener.java
@@ -27,6 +27,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.config.Config;
@@ -73,6 +74,11 @@ public class CubeNPCListener implements Listener {
 	 */
 	@EventHandler
 	public void onNPCClick(final PlayerInteractEvent event) {
+		// Only fire the event for the main hand to avoid that the event is triggered two times.
+		if (event.getHand() == EquipmentSlot.OFF_HAND && event.getHand() != null) {
+			return; // off hand packet, ignore.
+		}
+
 		if (event.isCancelled()) {
 			return;
 		}

--- a/src/main/java/pl/betoncraft/betonquest/objectives/ActionObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/ActionObjective.java
@@ -25,6 +25,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.Instruction;
@@ -75,6 +76,10 @@ public class ActionObjective extends Objective implements Listener {
 	@SuppressWarnings("deprecation")
 	@EventHandler
 	public void onInteract(PlayerInteractEvent event) {
+		// Only fire the event for the main hand to avoid that the event is triggered two times.
+		if (event.getHand() == EquipmentSlot.OFF_HAND && event.getHand() != null) {
+			return; // off hand packet, ignore.
+		}
 		String playerID = PlayerConverter.getID(event.getPlayer());
 		if (!containsPlayer(playerID)) {
 			return;

--- a/src/main/java/pl/betoncraft/betonquest/objectives/StepObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/StepObjective.java
@@ -25,6 +25,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.Instruction;
@@ -52,6 +53,10 @@ public class StepObjective extends Objective implements Listener {
 
 	@EventHandler
 	public void onStep(PlayerInteractEvent event) {
+		// Only fire the event for the main hand to avoid that the event is triggered two times.
+		if (event.getHand() == EquipmentSlot.OFF_HAND && event.getHand() != null) {
+			return; // off hand packet, ignore.
+		}
 		if (event.getAction() != Action.PHYSICAL) {
 			return;
 		}


### PR DESCRIPTION
Since Minecraft 1.10 the PlayerInteractEvent would be fired twice because of the implementation of the off-hand / shield hand.

To avoid it the plugin should ignore one hand.

In this commit I ignored the off-hand.