### PR TITLE
Fix #573 - Show NPC's head instead of default one in chest conversation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,10 @@
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots</url>
 		</repository>
 		<repository>
+			<id>dmulloy2-repo</id>
+			<url>http://repo.dmulloy2.net/content/groups/public/</url>
+		</repository>
+		<repository>
 			<id>betonquest-repo</id>
 			<url>http://betonquest.betoncraft.pl/mvn</url>
 		</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
+			<artifactId>spigot</artifactId>
 			<version>1.11.2-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>

--- a/src/main/java/pl/betoncraft/betonquest/AnswerFilter.java
+++ b/src/main/java/pl/betoncraft/betonquest/AnswerFilter.java
@@ -44,29 +44,6 @@ public class AnswerFilter implements Filter {
 	}
 
 	@Override
-	public State getState() {
-		return null;
-	}
-
-	@Override
-	public boolean isStarted() {
-		return false;
-	}
-
-	@Override
-	public boolean isStopped() {
-		return false;
-	}
-
-	@Override
-	public void start() {
-	}
-
-	@Override
-	public void stop() {
-	}
-
-	@Override
 	public Result filter(Logger arg0, Level arg1, Marker arg2, String arg3, Object... arg4) {
 		return null;
 	}

--- a/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -17,8 +17,10 @@
  */
 package pl.betoncraft.betonquest.conversation;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
@@ -37,7 +39,12 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+
+import net.citizensnpcs.api.npc.NPC;
 import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.compatibility.citizens.CitizensConversation;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
 /**
@@ -142,6 +149,21 @@ public class InventoryConvIO implements Listener, ConversationIO {
 		npcMeta.setOwner(npcName);
 		npcMeta.setDisplayName(npcNameColor + npcName);
 		npcMeta.setLore(stringToLines(response, npcTextColor, null));
+		CitizensConversation citizensConv = (CitizensConversation) conv;
+		String texture = citizensConv.getNPC().data().get(NPC.PLAYER_SKIN_TEXTURE_PROPERTIES_METADATA);
+		if (texture != null) { // Can be null if not cached yet
+			GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+			Property property = new Property("textures", texture, citizensConv.getNPC().data().get(NPC.PLAYER_SKIN_TEXTURE_PROPERTIES_SIGN_METADATA));
+			profile.getProperties().put("textures", property);
+
+			try {
+				Field field = npcMeta.getClass().getDeclaredField("profile");
+				field.setAccessible(true);
+				field.set(npcMeta, profile);
+			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+				e.printStackTrace();
+			}
+		}
 		npc.setItemMeta(npcMeta);
 		buttons[0] = npc;
 		// this is the number of an option


### PR DESCRIPTION
~~To compile you need to run BuildTools at least once otherwise the **spigot** dependency will be missing. Maybe run BuildTools on Travis as well.~~ I added dmulloy2's repository to provide the spigot dependency as BuildTools fails every time on Travis.

I had to modify AnswerFilter to fix the build with spigot's embedded log4j.