### PR TITLE
This should fix the issues with itemCount

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/conditions/ItemCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/ItemCondition.java
@@ -47,6 +47,7 @@ public class ItemCondition extends Condition {
 	public boolean check(String playerID) throws QuestRuntimeException {
 		int counter = 0;
 		for (Item questItem : questItems) {
+			boolean skipBackpack=false;
 			int amount = questItem.getAmount().getInt(playerID);
 			ItemStack[] inventoryItems = PlayerConverter.getPlayer(playerID).getInventory().getContents();
 			for (ItemStack item : inventoryItems) {
@@ -59,9 +60,11 @@ public class ItemCondition extends Condition {
 				amount -= item.getAmount();
 				if (amount <= 0) {
 					counter++;
+					skipBackpack=true;
 					break;
 				}
 			}
+			if(skipBackpack) continue;
 			List<ItemStack> backpackItems = BetonQuest.getInstance().getPlayerData(playerID).getBackpack();
 			for (ItemStack item : backpackItems) {
 				if (item == null) {
@@ -77,6 +80,6 @@ public class ItemCondition extends Condition {
 				}
 			}
 		}
-		return counter >= questItems.length;
+		return counter == questItems.length;
 	}
 }


### PR DESCRIPTION
skip the check for Backpack so the counter isn't increased more than 1 time for each item.
I did this online only, as eclipse is not letting me import it due to bad connection. But I hope everything is correct.