### PR TITLE
Treat commands as chat input in PasswordObjective

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/objectives/PasswordObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/PasswordObjective.java
@@ -18,11 +18,13 @@
 package pl.betoncraft.betonquest.objectives;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import pl.betoncraft.betonquest.BetonQuest;
@@ -51,13 +53,25 @@ public class PasswordObjective extends Objective implements Listener {
 
 	@EventHandler(priority = EventPriority.LOW)
 	public void onChat(AsyncPlayerChatEvent event) {
-		final String playerID = PlayerConverter.getID(event.getPlayer());
+		if(chatInput(event.getPlayer(), event.getMessage())) {
+			event.setCancelled(true);
+		}
+	}
+	@EventHandler(priority = EventPriority.LOW)
+	public void onCommand(PlayerCommandPreprocessEvent event) {
+		System.out.println(event.getMessage());
+		if(chatInput(event.getPlayer(), event.getMessage())) {
+			event.setCancelled(true);
+		}
+	}
+
+	private boolean chatInput(Player player, String message) {
+		final String playerID = PlayerConverter.getID(player);
 		if (containsPlayer(playerID)) {
 			String prefix = Config.getMessage(BetonQuest.getInstance().getPlayerData(playerID).getLanguage(),
 					"password");
-			if (event.getMessage().startsWith(prefix)) {
-				event.setCancelled(true);
-				String password = event.getMessage().substring(prefix.length());
+			if (message.startsWith(prefix)) {
+				String password = message.substring(prefix.length());
 				if (ignoreCase) {
 					if (password.toLowerCase().matches(regex) && checkConditions(playerID))
 						new BukkitRunnable() {
@@ -75,8 +89,10 @@ public class PasswordObjective extends Objective implements Listener {
 							}
 						}.runTask(BetonQuest.getInstance());
 				}
+				return true;
 			}
 		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/pl/betoncraft/betonquest/objectives/PasswordObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/PasswordObjective.java
@@ -53,19 +53,18 @@ public class PasswordObjective extends Objective implements Listener {
 
 	@EventHandler(priority = EventPriority.LOW)
 	public void onChat(AsyncPlayerChatEvent event) {
-		if(chatInput(event.getPlayer(), event.getMessage())) {
+		if(chatInput(false, event.getPlayer(), event.getMessage())) {
 			event.setCancelled(true);
 		}
 	}
 	@EventHandler(priority = EventPriority.LOW)
 	public void onCommand(PlayerCommandPreprocessEvent event) {
-		System.out.println(event.getMessage());
-		if(chatInput(event.getPlayer(), event.getMessage())) {
+		if(chatInput(true, event.getPlayer(), event.getMessage())) {
 			event.setCancelled(true);
 		}
 	}
 
-	private boolean chatInput(Player player, String message) {
+	private boolean chatInput(boolean fromCommand, Player player, String message) {
 		final String playerID = PlayerConverter.getID(player);
 		if (containsPlayer(playerID)) {
 			String prefix = Config.getMessage(BetonQuest.getInstance().getPlayerData(playerID).getLanguage(),
@@ -73,23 +72,27 @@ public class PasswordObjective extends Objective implements Listener {
 			if (message.startsWith(prefix)) {
 				String password = message.substring(prefix.length());
 				if (ignoreCase) {
-					if (password.toLowerCase().matches(regex) && checkConditions(playerID))
+					if (password.toLowerCase().matches(regex) && checkConditions(playerID)) {
 						new BukkitRunnable() {
 							@Override
 							public void run() {
 								completeObjective(playerID);
 							}
 						}.runTask(BetonQuest.getInstance());
+						return true;
+					}
 				} else {
-					if (password.matches(regex) && checkConditions(playerID))
+					if (password.matches(regex) && checkConditions(playerID)) {
 						new BukkitRunnable() {
 							@Override
 							public void run() {
 								completeObjective(playerID);
 							}
 						}.runTask(BetonQuest.getInstance());
+						return true;
+					}
 				}
-				return true;
+				if(!fromCommand || !prefix.isEmpty()) return true;
 			}
 		}
 		return false;


### PR DESCRIPTION
I added the PlayerCommandPreprocessEvent to the PasswordObjective. Every command will be treated like an input in the chat (but with a / at the start).

This has two advantages:
- the password prefix in the message.yml could be set to '/password ' and you could realize a "/password [password]" command
- if the password prefix is set to '' (empty)  the password could start with a "/". This is helpful if the solution to a quest is a command.