### PR TITLE
Tab completation var2

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/commands/LangCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/LangCommand.java
@@ -29,15 +29,19 @@ import pl.betoncraft.betonquest.database.PlayerData;
 import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Changes the default language for the player
  * 
  * @author Jakub Sapalski
  */
-public class LangCommand implements CommandExecutor {
+public class LangCommand implements CommandExecutor, SimpleTabCompleter {
 
 	public LangCommand() {
 		BetonQuest.getInstance().getCommand("questlang").setExecutor(this);
+		BetonQuest.getInstance().getCommand("questlang").setTabCompleter(this);
 	}
 
 	@Override
@@ -82,5 +86,13 @@ public class LangCommand implements CommandExecutor {
 			return true;
 		}
 		return false;
+	}
+
+	@Override
+	public List<String> simpleTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		if (args.length == 1) {
+			return Config.getLanguages();
+		}
+		return new ArrayList<>();
 	}
 }

--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -363,7 +363,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	 */
 	private List<String> completeId(CommandSender sender, String[] args, ConfigAccessor.AccessorType type) {
 		String last = args[args.length - 1];
-		if (last == null | !last.contains(".")) {
+		if (last == null || !last.contains(".")) {
 			return completePackage(sender, args);
 		} else {
 			String pack = last.substring(0,last.indexOf("."));
@@ -1138,7 +1138,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	 */
 	private List<String> completeVector(CommandSender sender, String[] args) {
 		if (args.length == 2) {
-			if (args[1] == null | !args[1].contains(".")) {
+			if (args[1] == null || !args[1].contains(".")) {
 				return completePackage(sender, args);
 			}
 			String pack = args[1].substring(0,args[1].indexOf("."));

--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -363,7 +363,35 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	private List<String> completeId(CommandSender sender, String[] args, ConfigAccessor.AccessorType type) {
 		String last = args[args.length - 1];
 		if (last == null || !last.contains(".")) {
-			return completePackage(sender, args);
+			List<String> completations = new ArrayList<>(completePackage(sender, args));
+			completations.remove(Config.getDefaultPackage());
+			ConfigPackage deFault = Config.getPackages().get(Config.getDefaultPackage());
+			if (type == null) return completations;
+			ConfigAccessor accessor;
+			switch (type) {
+				case ITEMS:
+					accessor = deFault.getItems();
+					break;
+				case EVENTS:
+					accessor = deFault.getEvents();
+					break;
+				case JOURNAL:
+					accessor = deFault.getJournal();
+					break;
+				case CONDITIONS:
+					accessor = deFault.getConditions();
+					break;
+				case OBJECTIVES:
+					accessor = deFault.getObjectives();
+					break;
+				default:
+					return completations;
+			}
+			FileConfiguration configuration = accessor.getConfig();
+			for (String key : configuration.getKeys(false)) {
+				completations.add(key);
+			}
+			return completations;
 		} else {
 			String pack = last.substring(0,last.indexOf("."));
 			ConfigPackage configPack = Config.getPackages().get(pack);
@@ -653,7 +681,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	private List<String> completeJournals(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return Arrays.asList("add", "list", "del");
-		if (args.length == 4) return completeJournals(sender, args);
+		if (args.length == 4) return completeId(sender, args, ConfigAccessor.AccessorType.JOURNAL);
 		return new ArrayList<>();
 	}
 

--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -67,7 +67,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	private String defaultPack = Config.getString("config.default_package");
 
 	/**
-	 * Registers a new executor of the /betonquest command
+	 * Registers a new executor and a new tab completer of the /betonquest command
 	 */
 	public QuestCommand() {
 		BetonQuest.getInstance().getCommand("betonquest").setExecutor(this);
@@ -275,7 +275,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 			        "purge",
 			        "backup");
 		}
-		switch (args[0]) {
+		switch (args[0].toLowerCase()) {
             case "conditions":
             case "condition":
             case "c":
@@ -333,15 +333,34 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
         }
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest update command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeUpdate(CommandSender sender, String[] args) {
 		if (args.length == 2) return Arrays.asList("--dev");
 		else return new ArrayList<>();
 	}
 
+	/**
+	 * Returns a list of all packages for the tab completer
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completePackage(CommandSender sender, String[] args) {
 		return new ArrayList<>(Config.getPackages().keySet());
 	}
 
+	/**
+	 * Returns a list including all possible tab complete options for ids
+	 * @param sender
+	 * @param args
+	 * @param type - the type of the Id (item/event/journal/condition/objective), null for unspecific
+	 * @return
+	 */
 	private List<String> completeId(CommandSender sender, String[] args, ConfigAccessor.AccessorType type) {
 		String last = args[args.length - 1];
 		if (last == null | !last.contains(".")) {
@@ -534,6 +553,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		}
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest config command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeConfig(CommandSender sender, String[] args) {
 		if (args.length == 2) return Arrays.asList("set", "add" , "read");
 		return new ArrayList<>();
@@ -620,6 +645,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		}
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest journal command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeJournals(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return Arrays.asList("add", "list", "del");
@@ -695,6 +726,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		}
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest points command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completePoints(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return Arrays.asList("add", "list", "del");
@@ -754,6 +791,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest item command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeItems(CommandSender sender, String[] args) {
 		if (args.length == 2) return completeId(sender, args, ConfigAccessor.AccessorType.ITEMS);
 		return new ArrayList<>();
@@ -787,6 +830,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		sendMessage(sender, "player_event", new String[] { eventID.generateInstruction().getInstruction() });
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest event command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeEvents(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return completeId(sender, args, ConfigAccessor.AccessorType.EVENTS);
@@ -823,6 +872,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 				Boolean.toString(BetonQuest.condition(playerID, conditionID)) });
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest condition command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
     private List<String> completeConditions(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return completeId(sender, args, ConfigAccessor.AccessorType.CONDITIONS);
@@ -891,6 +946,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		}
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest tags command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeTags(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return Arrays.asList("list", "add", "del");
@@ -1005,6 +1066,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		}
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest objectives command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeObjectives(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return Arrays.asList("list", "add", "del", "complete");
@@ -1063,6 +1130,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		player.sendMessage("§2OK");
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest vector command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeVector(CommandSender sender, String[] args) {
 		if (args.length == 2) {
 			if (args[1] == null | !args[1].contains(".")) {
@@ -1204,6 +1277,12 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		sendMessage(sender, "everything_renamed");
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest rename command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeRenaming(CommandSender sender, String[] args) {
 		if (args.length <= 3) return completeDeleting(sender, args);
 		if (args.length == 4) return completeId(sender, args, null);
@@ -1280,10 +1359,16 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		sendMessage(sender, "everything_removed");
 	}
 
+	/**
+	 * Returns a list including all possible options for tab complete of the /betonquest delete command
+	 * @param sender
+	 * @param args
+	 * @return
+	 */
 	private List<String> completeDeleting(CommandSender sender, String[] args) {
 		if (args.length == 2) return Arrays.asList("tag", "point", "objective", "entry");
 		if (args.length == 3) {
-			switch (args[1]) {
+			switch (args[1].toLowerCase()) {
 				case "tags":
 				case "tag":
 				case "t":

--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -1,17 +1,17 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,11 +19,7 @@ package pl.betoncraft.betonquest.commands;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -31,6 +27,8 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -60,10 +58,10 @@ import pl.betoncraft.betonquest.utils.Utils;
 
 /**
  * Main admin command for quest editing.
- * 
+ *
  * @author Jakub Sapalski
  */
-public class QuestCommand implements CommandExecutor {
+public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 
 	private BetonQuest instance = BetonQuest.getInstance();
 	private String defaultPack = Config.getString("config.default_package");
@@ -256,6 +254,134 @@ public class QuestCommand implements CommandExecutor {
 		return false;
 	}
 
+	@Override
+	public List<String> simpleTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		if (args.length == 1) {
+			return Arrays.asList(
+					"reload",
+			        "objective",
+			        "tag",
+			        "point",
+			        "journal",
+			        "condition",
+			        "event",
+			        "item",
+			        "give",
+			        "rename",
+			        "delete",
+			        "config",
+			        "vector",
+			        "purge",
+			        "backup");
+		}
+		switch (args[0]) {
+            case "conditions":
+            case "condition":
+            case "c":
+				return completeConditions(sender, args);
+            case "events":
+            case "event":
+            case "e":
+                return completeEvents(sender, args);
+            case "items":
+            case "item":
+            case "i":
+            case "give":
+            case "g":
+                return completeItems(sender, args);
+            case "config":
+                return completeConfig(sender, args);
+            case "objectives":
+            case "objective":
+            case "o":
+                return completeObjectives(sender, args);
+            case "tags":
+            case "tag":
+            case "t":
+                return completeTags(sender, args);
+            case "points":
+            case "point":
+            case "p":
+                return completePoints(sender, args);
+            case "journals":
+            case "journal":
+            case "j":
+                return completeJournals(sender, args);
+            case "delete":
+            case "del":
+            case "d":
+                return completeDeleting(sender, args);
+            case "rename":
+            case "r":
+                return completeRenaming(sender, args);
+            case "vector":
+            case "vec":
+            case "v":
+            	return completeVector(sender, args);
+            case "purge":
+                return null;
+            case "update":
+            	return completeUpdate(sender, args);
+            case "reload":
+			case "backup":
+			case "create":
+			case "package":
+			default:
+                return new ArrayList<>();
+        }
+	}
+
+	private List<String> completeUpdate(CommandSender sender, String[] args) {
+		if (args.length == 2) return Arrays.asList("--dev");
+		else return new ArrayList<>();
+	}
+
+	private List<String> completePackage(CommandSender sender, String[] args) {
+		return new ArrayList<>(Config.getPackages().keySet());
+	}
+
+	private List<String> completeId(CommandSender sender, String[] args, ConfigAccessor.AccessorType type) {
+		String last = args[args.length - 1];
+		if (last == null | !last.contains(".")) {
+			return completePackage(sender, args);
+		} else {
+			String pack = last.substring(0,last.indexOf("."));
+			ConfigPackage configPack = Config.getPackages().get(pack);
+			if (configPack == null) return new ArrayList<>();
+			if (type == null) {
+				List<String> completations = new ArrayList<>();
+				completations.add(pack + ".");
+				return completations;
+			}
+			ConfigAccessor accessor;
+			switch (type) {
+				case ITEMS:
+					accessor = configPack.getItems();
+					break;
+				case EVENTS:
+					accessor = configPack.getEvents();
+					break;
+				case JOURNAL:
+					accessor = configPack.getJournal();
+					break;
+				case CONDITIONS:
+					accessor = configPack.getConditions();
+					break;
+				case OBJECTIVES:
+					accessor = configPack.getObjectives();
+					break;
+				default:
+					return new ArrayList<>();
+			}
+			FileConfiguration configuration = accessor.getConfig();
+			List<String> completations = new ArrayList<>();
+			for (String key : configuration.getKeys(false)) {
+				completations.add(pack + "." + key);
+			}
+			return completations;
+		}
+	}
+
 	/**
 	 * Gives an item to the player
 	 */
@@ -406,6 +532,11 @@ public class QuestCommand implements CommandExecutor {
 		}
 	}
 
+	private List<String> completeConfig(CommandSender sender, String[] args) {
+		if (args.length == 2) return Arrays.asList("set", "add" , "read");
+		return new ArrayList<>();
+	}
+
 	/**
 	 * Lists, adds or removes journal entries of certain players
 	 */
@@ -487,6 +618,13 @@ public class QuestCommand implements CommandExecutor {
 		}
 	}
 
+	private List<String> completeJournals(CommandSender sender, String[] args) {
+		if (args.length == 2) return null;
+		if (args.length == 3) return Arrays.asList("add", "list", "del");
+		if (args.length == 4) return completeJournals(sender, args);
+		return new ArrayList<>();
+	}
+
 	/**
 	 * Lists, adds or removes points of certain player
 	 */
@@ -555,6 +693,13 @@ public class QuestCommand implements CommandExecutor {
 		}
 	}
 
+	private List<String> completePoints(CommandSender sender, String[] args) {
+		if (args.length == 2) return null;
+		if (args.length == 3) return Arrays.asList("add", "list", "del");
+		if (args.length == 4) return completeId(sender, args, null);
+		return new ArrayList<>();
+	}
+
 	/**
 	 * Adds item held in hand to items.yml file
 	 */
@@ -604,7 +749,12 @@ public class QuestCommand implements CommandExecutor {
 		config.saveConfig();
 		// done
 		sendMessage(sender, "item_created", new String[] { args[1] });
-		
+
+	}
+
+	private List<String> completeItems(CommandSender sender, String[] args) {
+		if (args.length == 2) return completeId(sender, args, ConfigAccessor.AccessorType.ITEMS);
+		return new ArrayList<>();
 	}
 
 	/**
@@ -633,6 +783,12 @@ public class QuestCommand implements CommandExecutor {
 		// fire the event
 		BetonQuest.event(playerID, eventID);
 		sendMessage(sender, "player_event", new String[] { eventID.generateInstruction().getInstruction() });
+	}
+
+	private List<String> completeEvents(CommandSender sender, String[] args) {
+		if (args.length == 2) return null;
+		if (args.length == 3) return completeId(sender, args, ConfigAccessor.AccessorType.EVENTS);
+		return new ArrayList<>();
 	}
 
 	/**
@@ -664,6 +820,12 @@ public class QuestCommand implements CommandExecutor {
 				+ conditionID.generateInstruction().getInstruction(),
 				Boolean.toString(BetonQuest.condition(playerID, conditionID)) });
 	}
+
+    private List<String> completeConditions(CommandSender sender, String[] args) {
+		if (args.length == 2) return null;
+		if (args.length == 3) return completeId(sender, args, ConfigAccessor.AccessorType.CONDITIONS);
+        return new ArrayList<>();
+    }
 
 	/**
 	 * Lists, adds or removes tags
@@ -725,6 +887,13 @@ public class QuestCommand implements CommandExecutor {
 			sendMessage(sender, "unknown_argument");
 			break;
 		}
+	}
+
+	private List<String> completeTags(CommandSender sender, String[] args) {
+		if (args.length == 2) return null;
+		if (args.length == 3) return Arrays.asList("list" + "add" + "del");
+		if (args.length == 4) return completeId(sender, args, null);
+		return new ArrayList<>();
 	}
 
 	/**
@@ -834,9 +1003,16 @@ public class QuestCommand implements CommandExecutor {
 		}
 	}
 
+	private List<String> completeObjectives(CommandSender sender, String[] args) {
+		if (args.length == 2) return null;
+		if (args.length == 3) return Arrays.asList("list", "add", "del", "complete");
+		if (args.length == 4) return completeId(sender, args, ConfigAccessor.AccessorType.OBJECTIVES);
+		return new ArrayList<>();
+	}
+
 	/**
 	 * Creates a vector variable
-	 * 
+	 *
 	 * @param sender
 	 * @param args
 	 */
@@ -883,6 +1059,22 @@ public class QuestCommand implements CommandExecutor {
 		Config.setString(pack + ".main.variables.vectors." + args[2],
 				String.format("$%s$->(%.2f,%.2f,%.2f)", name, x, y, z));
 		player.sendMessage("§2OK");
+	}
+
+	private List<String> completeVector(CommandSender sender, String[] args) {
+		if (args.length == 2) {
+			if (args[1] == null | !args[1].contains(".")) {
+				return completePackage(sender, args);
+			}
+			String pack = args[1].substring(0,args[1].indexOf("."));
+			ConfigPackage configPack = Config.getPackages().get(pack);
+			if (configPack == null) return new ArrayList<>();
+			ConfigurationSection section = configPack.getMain().getConfig().getConfigurationSection("variables");
+			Collection<String> keys = section.getKeys(false);
+			if (keys.isEmpty()) return new ArrayList<>();
+			return new ArrayList<>(keys);
+		}
+		return new ArrayList<>();
 	}
 
 	/**
@@ -1010,6 +1202,12 @@ public class QuestCommand implements CommandExecutor {
 		sendMessage(sender, "everything_renamed");
 	}
 
+	private List<String> completeRenaming(CommandSender sender, String[] args) {
+		if (args.length <= 3) return completeDeleting(sender, args);
+		if (args.length == 4) return completeId(sender, args, null);
+		return new ArrayList<>();
+	}
+
 	/**
 	 * Deleted stuff.
 	 */
@@ -1078,6 +1276,33 @@ public class QuestCommand implements CommandExecutor {
 		}
 		BetonQuest.getInstance().getSaver().add(new Record(updateType, new String[] { name }));
 		sendMessage(sender, "everything_removed");
+	}
+
+	private List<String> completeDeleting(CommandSender sender, String[] args) {
+		if (args.length == 2) return Arrays.asList("tag" + "point" + "objective" + "entry");
+		if (args.length == 3) {
+			switch (args[1]) {
+				case "tags":
+				case "tag":
+				case "t":
+				case "points":
+				case "point":
+				case "p":
+					return completeId(sender, args, null);
+				case "objectives":
+				case "objective":
+				case "o":
+					return completeId(sender, args, ConfigAccessor.AccessorType.OBJECTIVES);
+				case "journals":
+				case "journal":
+				case "j":
+				case "entries":
+				case "entry":
+				case "e":
+					return completeId(sender, args, ConfigAccessor.AccessorType.JOURNAL);
+			}
+		}
+		return new ArrayList<>();
 	}
 
 	/**

--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -71,6 +71,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	 */
 	public QuestCommand() {
 		BetonQuest.getInstance().getCommand("betonquest").setExecutor(this);
+		BetonQuest.getInstance().getCommand("betonquest").setTabCompleter(this);
 	}
 
 	@Override
@@ -319,7 +320,8 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
             case "v":
             	return completeVector(sender, args);
             case "purge":
-                return null;
+                if (args.length == 2) return null;
+                else return new ArrayList<>();
             case "update":
             	return completeUpdate(sender, args);
             case "reload":
@@ -891,7 +893,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 
 	private List<String> completeTags(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
-		if (args.length == 3) return Arrays.asList("list" + "add" + "del");
+		if (args.length == 3) return Arrays.asList("list", "add", "del");
 		if (args.length == 4) return completeId(sender, args, null);
 		return new ArrayList<>();
 	}
@@ -1279,7 +1281,7 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	}
 
 	private List<String> completeDeleting(CommandSender sender, String[] args) {
-		if (args.length == 2) return Arrays.asList("tag" + "point" + "objective" + "entry");
+		if (args.length == 2) return Arrays.asList("tag", "point", "objective", "entry");
 		if (args.length == 3) {
 			switch (args[1]) {
 				case "tags":

--- a/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/QuestCommand.java
@@ -260,77 +260,76 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 		if (args.length == 1) {
 			return Arrays.asList(
 					"reload",
-			        "objective",
-			        "tag",
-			        "point",
-			        "journal",
-			        "condition",
-			        "event",
-			        "item",
-			        "give",
-			        "rename",
-			        "delete",
-			        "config",
-			        "vector",
-			        "purge",
-			        "backup");
+					"objective",
+					"tag",
+					"point",
+					"journal",
+					"condition",
+					"event",
+					"item",
+					"give",
+					"rename",
+					"delete",
+					"config",
+					"vector",
+					"backup");
 		}
 		switch (args[0].toLowerCase()) {
-            case "conditions":
-            case "condition":
-            case "c":
+			case "conditions":
+			case "condition":
+			case "c":
 				return completeConditions(sender, args);
-            case "events":
-            case "event":
-            case "e":
-                return completeEvents(sender, args);
-            case "items":
-            case "item":
-            case "i":
-            case "give":
-            case "g":
-                return completeItems(sender, args);
-            case "config":
-                return completeConfig(sender, args);
-            case "objectives":
-            case "objective":
-            case "o":
-                return completeObjectives(sender, args);
-            case "tags":
-            case "tag":
-            case "t":
-                return completeTags(sender, args);
-            case "points":
-            case "point":
-            case "p":
-                return completePoints(sender, args);
-            case "journals":
-            case "journal":
-            case "j":
-                return completeJournals(sender, args);
-            case "delete":
-            case "del":
-            case "d":
-                return completeDeleting(sender, args);
-            case "rename":
-            case "r":
-                return completeRenaming(sender, args);
-            case "vector":
-            case "vec":
-            case "v":
-            	return completeVector(sender, args);
-            case "purge":
-                if (args.length == 2) return null;
-                else return new ArrayList<>();
-            case "update":
-            	return completeUpdate(sender, args);
-            case "reload":
+			case "events":
+			case "event":
+			case "e":
+				return completeEvents(sender, args);
+			case "items":
+			case "item":
+			case "i":
+			case "give":
+			case "g":
+				return completeItems(sender, args);
+			case "config":
+				return completeConfig(sender, args);
+			case "objectives":
+			case "objective":
+			case "o":
+				return completeObjectives(sender, args);
+			case "tags":
+			case "tag":
+			case "t":
+				return completeTags(sender, args);
+			case "points":
+			case "point":
+			case "p":
+				return completePoints(sender, args);
+			case "journals":
+			case "journal":
+			case "j":
+				return completeJournals(sender, args);
+			case "delete":
+			case "del":
+			case "d":
+				return completeDeleting(sender, args);
+			case "rename":
+			case "r":
+				return completeRenaming(sender, args);
+			case "vector":
+			case "vec":
+			case "v":
+				return completeVector(sender, args);
+			case "purge":
+				if (args.length == 2) return null;
+				else return new ArrayList<>();
+			case "update":
+				return completeUpdate(sender, args);
+			case "reload":
 			case "backup":
 			case "create":
 			case "package":
 			default:
-                return new ArrayList<>();
-        }
+				return new ArrayList<>();
+		}
 	}
 
 	/**
@@ -878,11 +877,11 @@ public class QuestCommand implements CommandExecutor,SimpleTabCompleter {
 	 * @param args
 	 * @return
 	 */
-    private List<String> completeConditions(CommandSender sender, String[] args) {
+	private List<String> completeConditions(CommandSender sender, String[] args) {
 		if (args.length == 2) return null;
 		if (args.length == 3) return completeId(sender, args, ConfigAccessor.AccessorType.CONDITIONS);
-        return new ArrayList<>();
-    }
+		return new ArrayList<>();
+	}
 
 	/**
 	 * Lists, adds or removes tags

--- a/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
@@ -32,19 +32,19 @@ import java.util.List;
 public interface SimpleTabCompleter extends TabCompleter {
 
 
-    @Override
-    default List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-        List<String> completations = this.simpleTabComplete(sender, command, alias, args);
-        if (completations == null) return null;
-        List<String> out = new ArrayList<>();
-        String lastArg = args[args.length - 1];
-        for (String completation : completations) {
-            if (lastArg == null || lastArg.matches(" *") || completation.toLowerCase().startsWith(lastArg.toLowerCase())) {
-                out.add(completation);
-            }
-        }
-        return out;
-    }
+	@Override
+	default List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		List<String> completations = this.simpleTabComplete(sender, command, alias, args);
+		if (completations == null) return null;
+		List<String> out = new ArrayList<>();
+		String lastArg = args[args.length - 1];
+		for (String completation : completations) {
+			if (lastArg == null || lastArg.matches(" *") || completation.toLowerCase().startsWith(lastArg.toLowerCase())) {
+				out.add(completation);
+			}
+		}
+		return out;
+	}
 
-    List<String> simpleTabComplete(CommandSender sender, Command command, String alias, String[] args);
+	List<String> simpleTabComplete(CommandSender sender, Command command, String alias, String[] args);
 }

--- a/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
@@ -23,7 +23,7 @@ public interface SimpleTabCompleter extends TabCompleter {
         List<String> out = new ArrayList<>();
         String lastArg = args[args.length - 1];
         for (String completation : completations) {
-            if (lastArg == null || lastArg.matches(" *") || completation.startsWith(lastArg)) {
+            if (lastArg == null || lastArg.matches(" *") || completation.toLowerCase().startsWith(lastArg.toLowerCase())) {
                 out.add(completation);
             }
         }

--- a/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
@@ -1,3 +1,20 @@
+/**
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package pl.betoncraft.betonquest.commands;
 
 import org.bukkit.command.Command;
@@ -8,10 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Licensed under GNU GENERAL PUBLIC LICENSE Version 3
- * https://gitlab.com/ungefroren/SchemGui/blob/master/LICENSE
- * <p>
- * Created by Jonas on 10.10.2017.
+ * Interface which handles tab complete for commands.
+ *
+ * @author Jonas Blocher
  */
 public interface SimpleTabCompleter extends TabCompleter {
 

--- a/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
+++ b/src/main/java/pl/betoncraft/betonquest/commands/SimpleTabCompleter.java
@@ -1,0 +1,34 @@
+package pl.betoncraft.betonquest.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Licensed under GNU GENERAL PUBLIC LICENSE Version 3
+ * https://gitlab.com/ungefroren/SchemGui/blob/master/LICENSE
+ * <p>
+ * Created by Jonas on 10.10.2017.
+ */
+public interface SimpleTabCompleter extends TabCompleter {
+
+
+    @Override
+    default List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completations = this.simpleTabComplete(sender, command, alias, args);
+        if (completations == null) return null;
+        List<String> out = new ArrayList<>();
+        String lastArg = args[args.length - 1];
+        for (String completation : completations) {
+            if (lastArg == null || lastArg.matches(" *") || completation.startsWith(lastArg)) {
+                out.add(completation);
+            }
+        }
+        return out;
+    }
+
+    List<String> simpleTabComplete(CommandSender sender, Command command, String alias, String[] args);
+}

--- a/src/main/java/pl/betoncraft/betonquest/config/Config.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/Config.java
@@ -340,7 +340,6 @@ public class Config {
 	public static boolean setString(String address, String value) {
 		if (address == null)
 			return false;
-		;
 		String[] parts = address.split("\\.");
 		if (parts.length < 2)
 			return false;


### PR DESCRIPTION
> **Co0sh in Add tab complete #629**:
> One more thing I noticed when testing this. It would be great if it showed both packages and events when completing IDs and also haven't showed default package, since you don't have to type it, like that:
> 
> (there are 3 packages: foo, bar and baz, default one is foo; every package contains 3 generic IDs)
> ```
> bar
> baz
> first
> second
> third
> bar.first
> bar.second
> bar.third
> baz.first
> baz.second
> baz.third
> ```
> This way you can autocomplete a package, then press dot and autocomplete the ID from that package.

Implemented it here. See other #629  for more information.