### PR TITLE
Fix #644 - Allow Citizens loading before EffectLib and ProtocolLib

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
@@ -46,7 +46,7 @@ public class CitizensIntegrator implements Integrator {
             NPCHider.start();
             plugin.registerEvents("updatevisibility", UpdateVisibilityNowEvent.class);
         }
-        // if EffectLib is hooked, start NPCHider
+        // if EffectLib is hooked, start CitizensParticle
         if (Compatibility.getHooked().contains("EffectLib"))
             new CitizensParticle();
     }

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.compatibility.Compatibility;
 import pl.betoncraft.betonquest.compatibility.Integrator;
+import pl.betoncraft.betonquest.compatibility.protocollib.NPCHider;
+import pl.betoncraft.betonquest.compatibility.protocollib.UpdateVisibilityNowEvent;
 
 
 public class CitizensIntegrator implements Integrator {
@@ -39,6 +41,14 @@ public class CitizensIntegrator implements Integrator {
         plugin.registerObjectives("npckill", NPCKillObjective.class);
         plugin.registerObjectives("npcinteract", NPCInteractObjective.class);
         plugin.registerEvents("movenpc", NPCMoveEvent.class);
+        // if ProtocolLib is hooked, start NPCHider
+        if (Compatibility.getHooked().contains("ProtocolLib")) {
+            NPCHider.start();
+            plugin.registerEvents("updatevisibility", UpdateVisibilityNowEvent.class);
+        }
+        // if EffectLib is hooked, start NPCHider
+        if (Compatibility.getHooked().contains("EffectLib"))
+            new CitizensParticle();
     }
 
     @Override


### PR DESCRIPTION
As I was working on BetonQuest anyway I just crated a quick fix for #644 to speed up the process of resolving this bug.