### PR TITLE
Add RealTimeCondition

### DIFF
--- a/docs/Conditions-List.md
+++ b/docs/Conditions-List.md
@@ -78,6 +78,12 @@ There must be specific (Minecraft) time on the player's world for this condition
 
 **Example**: `time 2-23`
 
+## Real time: `realtime`
+
+There must a specific (real) time for this condition to return true. You need to specify two times (formatted like `hh:mm`) separated by dash. If the first is before the second the time must be between these two, if its after the second the time must be later than the first and earlier than the second to return true.
+
+**Example:** `realtime 8:00-12:30`
+
 ## Weather: `weather`
 
 There must be a specific weather for this condition to return true. There are three possible options: sun, rain and storm. Note that `/toggledownfall` does not change the weather, it just does what the name suggests: toggles downfall. The rain toggled off will still be considered as rain! Use `/weather clear` instead.

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -47,6 +47,7 @@ import pl.betoncraft.betonquest.conditions.AchievementCondition;
 import pl.betoncraft.betonquest.conditions.AlternativeCondition;
 import pl.betoncraft.betonquest.conditions.ArmorCondition;
 import pl.betoncraft.betonquest.conditions.ArmorRatingCondition;
+import pl.betoncraft.betonquest.conditions.BiomeCondition;
 import pl.betoncraft.betonquest.conditions.CheckCondition;
 import pl.betoncraft.betonquest.conditions.ChestItemCondition;
 import pl.betoncraft.betonquest.conditions.ConjunctionCondition;
@@ -67,6 +68,7 @@ import pl.betoncraft.betonquest.conditions.PartyCondition;
 import pl.betoncraft.betonquest.conditions.PermissionCondition;
 import pl.betoncraft.betonquest.conditions.PointCondition;
 import pl.betoncraft.betonquest.conditions.RandomCondition;
+import pl.betoncraft.betonquest.conditions.RealTimeCondition;
 import pl.betoncraft.betonquest.conditions.ScoreboardCondition;
 import pl.betoncraft.betonquest.conditions.SneakCondition;
 import pl.betoncraft.betonquest.conditions.TagCondition;
@@ -76,7 +78,6 @@ import pl.betoncraft.betonquest.conditions.VariableCondition;
 import pl.betoncraft.betonquest.conditions.VehicleCondition;
 import pl.betoncraft.betonquest.conditions.WeatherCondition;
 import pl.betoncraft.betonquest.conditions.WorldCondition;
-import pl.betoncraft.betonquest.conditions.BiomeCondition;
 import pl.betoncraft.betonquest.config.Config;
 import pl.betoncraft.betonquest.config.ConfigPackage;
 import pl.betoncraft.betonquest.config.ConfigUpdater;
@@ -322,6 +323,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerConditions("variable", VariableCondition.class);
 		registerConditions("fly", FlyingCondition.class);
 		registerConditions("biome", BiomeCondition.class);
+		registerConditions("realtime", RealTimeCondition.class);
 
 		// register events
 		registerEvents("message", MessageEvent.class);

--- a/src/main/java/pl/betoncraft/betonquest/conditions/RealTimeCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/RealTimeCondition.java
@@ -1,0 +1,92 @@
+/**
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.betoncraft.betonquest.conditions;
+
+import pl.betoncraft.betonquest.Instruction;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.QuestRuntimeException;
+import pl.betoncraft.betonquest.api.Condition;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * A condition which checks if the current time is in the specified period
+ *
+ * Created by Jonas Blocher on 27.11.2017.
+ */
+public class RealTimeCondition extends Condition {
+
+    private final int hoursMin;
+    private final int minutesMin;
+    private final int hoursMax;
+    private final int minutesMax;
+
+    public RealTimeCondition(Instruction instruction) throws InstructionParseException {
+        super(instruction);
+        super.staticness = true;
+        super.persistent = true;
+        String[] theTime = instruction.next().split("-");
+        if (theTime.length != 2) {
+            throw new InstructionParseException("Wrong time format");
+        }
+        try {
+            String[] timeMin = theTime[0].split(":");
+            String[] timeMax = theTime[1].split(":");
+            if (timeMin.length != 2 || timeMax.length != 2) {
+                throw new InstructionParseException("Could not parse time");
+            }
+            hoursMin = Integer.parseInt(timeMin[0]);
+            minutesMin = Integer.parseInt(timeMin[1]);
+            hoursMax = Integer.parseInt(timeMax[0]);
+            minutesMax = Integer.parseInt(timeMax[1]);
+        } catch (NumberFormatException e) {
+            throw new InstructionParseException("Could not parse time");
+        }
+        if (hoursMax < 0 || hoursMax > 23) throw new InstructionParseException("Could not parse time");
+        if (hoursMin < 0 || hoursMin > 23) throw new InstructionParseException("Could not parse time");
+        if (minutesMax < 0 || minutesMax > 59) throw new InstructionParseException("Could not parse time");
+        if (minutesMin < 0 || minutesMin > 59) throw new InstructionParseException("Could not parse time");
+        if (hoursMin == hoursMax && minutesMin == minutesMax) throw new InstructionParseException("min and max time must be different");
+    }
+
+
+    @Override
+    public boolean check(String playerID) throws QuestRuntimeException {
+        Calendar cal = Calendar.getInstance();
+        Date now = cal.getTime();
+        Date startTime = atTime(cal, hoursMin, minutesMin);
+        Date endTime = atTime(cal, hoursMax, minutesMax);
+        if (startTime.before(endTime)) {
+            return now.after(startTime) && now.before(endTime);
+        } else {
+            return now.after(startTime) || now.before(endTime);
+        }
+    }
+
+    private Date atTime(Calendar day, int hours, int minutes) {
+        day.setLenient(false);
+        day.set(Calendar.HOUR_OF_DAY, hours);
+        day.set(Calendar.HOUR, hours < 12 ? hours : hours - 12);
+        day.set(Calendar.AM_PM, hours < 12 ? Calendar.AM : Calendar.PM);
+        day.set(Calendar.MINUTE, minutes);
+        day.set(Calendar.SECOND, 0);
+        day.set(Calendar.MILLISECOND, 0);
+        return day.getTime();
+    }
+}


### PR DESCRIPTION
 As discussed in #651. 

> ## Real time: `realtime`
> 
> There must a specific (real) time for this condition to return true. You need to specify two times (formatted like `hh:mm`) separated by dash. If the first is before the second the time must be between these two, if its after the second the time must be later than the first and earlier than the second to return true.
> 
> **Example:** `realtime 8:00-12:30`