### PR TITLE
MathVariable

### DIFF
--- a/docs/Variables-List.md
+++ b/docs/Variables-List.md
@@ -41,3 +41,9 @@ This variable displays the version of the plugin. You can optionally add the nam
 This variable resolves to player's current location, formatted as an absolute location format (more about it in the _Reference_ chapter). The location will contain yaw and pitch. You can use it instead of coordinates as location arguments in events, conditions and objectives.
 
 **Example**: `%location%`
+
+## Calculate mathematical expression: `math.calc`
+
+This variable allows you to perform a calculation based on other variables (for example point or objective variables) and resolves to the result of the specified calculation. The variable always starts with `math.calc:`, followed by the calculation which should be calculated. Supported operations are `+`, `-`, `*`, `/` and  `^`. You can use `( )` and `[ ]` braces and also calculate absolute values with `| |` (but don't use this in the command event as it splits the commands at every `|`). If you want to use variables in the calculation, don't put `%` around them.
+
+**Example:** `%math.calc:100*(15-point.reputation.amount)%`

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -164,7 +164,7 @@ import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 import pl.betoncraft.betonquest.utils.Updater;
 import pl.betoncraft.betonquest.utils.Utils;
-import pl.betoncraft.betonquest.variables.CalculateVariable;
+import pl.betoncraft.betonquest.variables.MathVariable;
 import pl.betoncraft.betonquest.variables.ItemAmountVariable;
 import pl.betoncraft.betonquest.variables.LocationVariable;
 import pl.betoncraft.betonquest.variables.NpcNameVariable;
@@ -405,7 +405,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerVariable("item", ItemAmountVariable.class);
 		registerVariable("version", VersionVariable.class);
 		registerVariable("location", LocationVariable.class);
-		registerVariable("calc", CalculateVariable.class);
+		registerVariable("math", MathVariable.class);
 
         // initialize compatibility with other plugins
         new Compatibility();

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -164,7 +164,14 @@ import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 import pl.betoncraft.betonquest.utils.Updater;
 import pl.betoncraft.betonquest.utils.Utils;
-import pl.betoncraft.betonquest.variables.*;
+import pl.betoncraft.betonquest.variables.CalculateVariable;
+import pl.betoncraft.betonquest.variables.ItemAmountVariable;
+import pl.betoncraft.betonquest.variables.LocationVariable;
+import pl.betoncraft.betonquest.variables.NpcNameVariable;
+import pl.betoncraft.betonquest.variables.ObjectivePropertyVariable;
+import pl.betoncraft.betonquest.variables.PlayerNameVariable;
+import pl.betoncraft.betonquest.variables.PointVariable;
+import pl.betoncraft.betonquest.variables.VersionVariable;
 
 /**
  * Represents BetonQuest plugin

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -164,13 +164,7 @@ import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 import pl.betoncraft.betonquest.utils.Updater;
 import pl.betoncraft.betonquest.utils.Utils;
-import pl.betoncraft.betonquest.variables.ItemAmountVariable;
-import pl.betoncraft.betonquest.variables.LocationVariable;
-import pl.betoncraft.betonquest.variables.NpcNameVariable;
-import pl.betoncraft.betonquest.variables.ObjectivePropertyVariable;
-import pl.betoncraft.betonquest.variables.PlayerNameVariable;
-import pl.betoncraft.betonquest.variables.PointVariable;
-import pl.betoncraft.betonquest.variables.VersionVariable;
+import pl.betoncraft.betonquest.variables.*;
 
 /**
  * Represents BetonQuest plugin
@@ -404,6 +398,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerVariable("item", ItemAmountVariable.class);
 		registerVariable("version", VersionVariable.class);
 		registerVariable("location", LocationVariable.class);
+		registerVariable("calc", CalculateVariable.class);
 
         // initialize compatibility with other plugins
         new Compatibility();

--- a/src/main/java/pl/betoncraft/betonquest/VariableNumber.java
+++ b/src/main/java/pl/betoncraft/betonquest/VariableNumber.java
@@ -117,4 +117,8 @@ public class VariableNumber {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return (variable == null ? String.valueOf(number) : variable.toString());
+	}
 }

--- a/src/main/java/pl/betoncraft/betonquest/api/Variable.java
+++ b/src/main/java/pl/betoncraft/betonquest/api/Variable.java
@@ -64,4 +64,8 @@ abstract public class Variable {
 	 */
 	public abstract String getValue(String playerID);
 
+	@Override
+	public String toString() {
+		return instruction.getInstruction();
+	}
 }

--- a/src/main/java/pl/betoncraft/betonquest/variables/CalculateVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/variables/CalculateVariable.java
@@ -1,0 +1,255 @@
+/**
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.betoncraft.betonquest.variables;
+
+import pl.betoncraft.betonquest.Instruction;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.QuestRuntimeException;
+import pl.betoncraft.betonquest.VariableNumber;
+import pl.betoncraft.betonquest.api.Variable;
+import pl.betoncraft.betonquest.config.ConfigPackage;
+import pl.betoncraft.betonquest.utils.Debug;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This variable evaluates the given calculation and returns the result.
+ *
+ * @author Jonas Blocher
+ */
+public class CalculateVariable extends Variable {
+
+    private final Calculable calculation;
+
+    public CalculateVariable(Instruction instruction) throws InstructionParseException {
+        super(instruction);
+        String instruction_string = instruction.getInstruction();
+        if (!instruction_string.matches("%calc:.+%")) throw new InstructionParseException("invalid format");
+        this.calculation = this.parse(instruction_string.substring(6, instruction_string.length() - 1));
+    }
+
+    @Override
+    public String getValue(String playerID) {
+        try {
+            return String.valueOf(this.calculation.calculate(playerID));
+        } catch (QuestRuntimeException e) {
+            Debug.error("Could not calculate '" + calculation.toString() + "' (" + e.getMessage() + "). Returning 0 instead.");
+            return "0";
+        }
+    }
+
+    /**
+     * Recursively parse a calculable object from the given calculation string which can be calculated in later process
+     * @param string the string which should be evaluated
+     * @return a calculable object which contains the whole calculation
+     * @throws InstructionParseException if the instruction isn't valid
+     */
+    private Calculable parse(final String string) throws InstructionParseException {
+        //calculate braces
+        if (string.matches("(\\(.+\\)|\\[.+])")) return this.parse(string.substring(1, string.length() - 1));
+        //calculate the absolute value
+        if (string.matches("\\|.+\\|")) return new AbsoluteValue(this.parse(string.substring(1, string.length() - 1)));
+        String tempCopy = string;
+        Matcher m = Pattern.compile("(\\(.+\\)|\\[.+]|\\|.+\\|)").matcher(tempCopy);
+        //ignore content of braces for all next operations
+        while (m.find()) {
+            final int start = m.start();
+            final int end = m.end();
+            final int length = end - start;
+            String s = tempCopy.substring(0, start + 1);
+            for (int i = 0; i < length - 2; i++) s += " ";
+            s += tempCopy.substring(end - 1, tempCopy.length());
+            tempCopy = s;
+        }
+        // ADDITION and SUBTRACTION
+        int i = tempCopy.lastIndexOf("+");
+        int j = tempCopy.lastIndexOf("-");
+        if (i > j) {
+            if (i == 0)
+                return new Calculation(new ClaculableVariable(0), this.parse(string.substring(1)), Operation.ADD);
+            //'+' comes after '-'
+            return new Calculation(this.parse(string.substring(0, i)),
+                                   this.parse(string.substring(i + 1)),
+                                   Operation.ADD);
+        } else if (j > i) {
+            if (j == 0)
+                return new Calculation(new ClaculableVariable(0), this.parse(string.substring(1)), Operation.SUBTRACT);
+            //'-' comes after '+'
+            return new Calculation(this.parse(string.substring(0, j)),
+                                   this.parse(string.substring(j + 1)),
+                                   Operation.SUBTRACT);
+        }
+        //MULTIPLY and DIVIDE
+        i = tempCopy.lastIndexOf("*");
+        j = tempCopy.lastIndexOf("/");
+        if (i > j) {
+            //'*' comes after '/'
+            return new Calculation(this.parse(string.substring(0, i)),
+                                   this.parse(string.substring(i + 1)),
+                                   Operation.MULTIPLY);
+        } else if (j > i) {
+            //'/' comes after '*'
+            return new Calculation(this.parse(string.substring(0, j)),
+                                   this.parse(string.substring(j + 1)),
+                                   Operation.DIVIDE);
+        }
+        //POW
+        i = tempCopy.lastIndexOf("^");
+        if (i != -1) {
+            return new Calculation(this.parse(string.substring(0, i)),
+                                   this.parse(string.substring(i + 1)),
+                                   Operation.POW);
+        }
+        //if string matches a number
+        if (string.matches("\\d+(\\.\\d+)?"))
+            return new ClaculableVariable(Double.parseDouble(string));
+        //if a variable is specified
+        try {
+            return new ClaculableVariable(super.pack, "%" + string + "%");
+        } catch (NumberFormatException e) {
+            throw new InstructionParseException(e.getMessage());
+        }
+    }
+
+    private enum Operation {
+        ADD('+'),
+        SUBTRACT('-'),
+        MULTIPLY('*'),
+        DIVIDE('/'),
+        POW('^');
+
+        private final char operator;
+
+        Operation(char operator) {
+            this.operator = operator;
+        }
+
+        static Operation fromOperator(char operator) {
+            for (Operation operation : values()) {
+                if (operation.operator == operator) return operation;
+            }
+            throw new IllegalArgumentException(operator + " is not a supported operator");
+        }
+
+        static Operation fromOperator(String operator) {
+            if (operator.length() != 1)
+                throw new IllegalArgumentException(operator + " is not a supported operator");
+            else return Operation.fromOperator(operator.charAt(0));
+        }
+
+        public char getOperator() {
+            return operator;
+        }
+    }
+
+    private interface Calculable {
+
+        double calculate(String playerId) throws QuestRuntimeException;
+    }
+
+    private static class ClaculableVariable implements Calculable {
+
+        private final VariableNumber variable;
+
+        public ClaculableVariable(VariableNumber variable) {
+            this.variable = variable;
+        }
+
+        public ClaculableVariable(double d) {
+            this(new VariableNumber(d));
+        }
+
+        public ClaculableVariable(ConfigPackage pack, String variable) throws NumberFormatException {
+            this(new VariableNumber(pack.getName(), variable));
+        }
+
+        @Override
+        public double calculate(String playerId) throws QuestRuntimeException {
+            return variable.getDouble(playerId);
+        }
+
+        @Override
+        public String toString() {
+            return variable.toString().replace("%", "");
+        }
+    }
+
+    private static class AbsoluteValue implements Calculable {
+
+        private final Calculable a;
+
+        public AbsoluteValue(Calculable a) {
+            this.a = a;
+        }
+
+        @Override
+        public String toString() {
+            return "|" + a + "|";
+        }
+
+        @Override
+        public double calculate(String playerId) throws QuestRuntimeException {
+            return Math.abs(a.calculate(playerId));
+        }
+    }
+
+    private static class Calculation implements Calculable {
+
+        private final Calculable a;
+        private final Calculable b;
+        private final Operation operation;
+
+        private Calculation(Calculable a, Calculable b, Operation operation) {
+            this.a = a;
+            this.b = b;
+            this.operation = operation;
+        }
+
+        @Override
+        public double calculate(String playerId) throws QuestRuntimeException {
+            try {
+                switch (operation) {
+                    case ADD:
+                        return a.calculate(playerId) + b.calculate(playerId);
+                    case SUBTRACT:
+                        return a.calculate(playerId) - b.calculate(playerId);
+                    case MULTIPLY:
+                        return a.calculate(playerId) * b.calculate(playerId);
+                    case DIVIDE:
+                        return a.calculate(playerId) / b.calculate(playerId);
+                    case POW:
+                        return Math.pow(a.calculate(playerId), b.calculate(playerId));
+                    default:
+                        throw new QuestRuntimeException("unsupported operation: " + operation);
+                }
+            } catch (ArithmeticException e) {
+                throw new QuestRuntimeException(e.getMessage());
+            }
+        }
+
+        @Override
+        public String toString() {
+            String a = ((this.a instanceof Calculation) || this.a.toString().startsWith("-"))
+                    ? ("(" + this.a.toString() + ")") : this.a.toString();
+            String b = ((this.b instanceof Calculation) || this.b.toString().startsWith("-"))
+                    ? ("(" + this.b.toString() + ")") : this.b.toString();
+            return a + operation.operator + b;
+        }
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/variables/CalculateVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/variables/CalculateVariable.java
@@ -40,7 +40,7 @@ public class CalculateVariable extends Variable {
     public CalculateVariable(Instruction instruction) throws InstructionParseException {
         super(instruction);
         String instruction_string = instruction.getInstruction();
-        if (!instruction_string.matches("%calc:.+%")) throw new InstructionParseException("invalid format");
+        if (!instruction_string.matches("calc:.+")) throw new InstructionParseException("invalid format");
         this.calculation = this.parse(instruction_string.substring(6, instruction_string.length() - 1));
     }
 


### PR DESCRIPTION
I thoght it would be very usefull to use variable numbers based on simple or more complex calculations therfore I created this variable.

> ## Calculate mathematical expression: `math.calc`
> 
> This variable allows you to perform a calculation based on other variables (for example point or objective variables) and resolves to the result of the specified calculation. The variable always starts with `math.calc:`, followed by the calculation which should be calculated. Supported operations are `+`, `-`, `*`, `/` and  `^`. You can use `( )` and `[ ]` braces and also calculate absolute values with `| |` (but don't use this in the command event as it splits the commands at every `|`). If you want to use variables in the calculation, don't put `%` around them.
> 
> **Example:** `%math.calc:100*(15-point.reputation.amount)%`