### PR TITLE
Close #702 - Add EXPEvent

### DIFF
--- a/docs/Events-List.md
+++ b/docs/Events-List.md
@@ -253,3 +253,9 @@ This event changes player's language to the specified one. There is only one arg
 ## Play sound: `playsound`
 
 This event will play a specified sound for the player. The only required argument is the sound name (can take custom values if you're using a resource pack). There are also a few optional arguments. `location:` makes the sound play at specified location, `category:` is the [sound category](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/SoundCategory.html) (if not specified it will use `MASTER`), `volume:` is a decimal responsible for the sound's volume and `pitch:` specifies the pitch.
+
+## Give experience: `xp`
+
+Gives the specified amount of experience points to the player. If you want to give whole levels to a player add the `level` argument.
+
+**Example:** `xp 4 level`

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -108,6 +108,7 @@ import pl.betoncraft.betonquest.events.CompassEvent;
 import pl.betoncraft.betonquest.events.ConversationEvent;
 import pl.betoncraft.betonquest.events.DamageEvent;
 import pl.betoncraft.betonquest.events.DoorEvent;
+import pl.betoncraft.betonquest.events.EXPEvent;
 import pl.betoncraft.betonquest.events.EffectEvent;
 import pl.betoncraft.betonquest.events.ExplosionEvent;
 import pl.betoncraft.betonquest.events.FolderEvent;
@@ -374,6 +375,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerEvents("title", TitleEvent.class);
 		registerEvents("language", LanguageEvent.class);
 		registerEvents("playsound", PlaysoundEvent.class);
+		registerEvents("xp", EXPEvent.class);
 
 		// register objectives
 		registerObjectives("location", LocationObjective.class);

--- a/src/main/java/pl/betoncraft/betonquest/events/EXPEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/events/EXPEvent.java
@@ -1,0 +1,54 @@
+/**
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.betoncraft.betonquest.events;
+
+import org.bukkit.entity.Player;
+import pl.betoncraft.betonquest.Instruction;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.QuestRuntimeException;
+import pl.betoncraft.betonquest.VariableNumber;
+import pl.betoncraft.betonquest.api.QuestEvent;
+import pl.betoncraft.betonquest.utils.PlayerConverter;
+
+/**
+ * Gives the player specified amount of experience
+ *
+ * @author Jonas Blocher
+ */
+public class EXPEvent extends QuestEvent {
+
+	private final VariableNumber amount;
+	private final boolean level;
+
+	public EXPEvent(Instruction instruction) throws InstructionParseException {
+		super(instruction);
+		this.amount = instruction.getVarNum();
+		this.level = instruction.hasArgument("level") || instruction.hasArgument("l");
+	}
+
+	@Override
+	public void run(String playerID) throws QuestRuntimeException {
+		Player player = PlayerConverter.getPlayer(playerID);
+		int amount = this.amount.getInt(playerID);
+		if (level) {
+			player.giveExpLevels(amount);
+		} else {
+			player.giveExp(amount);
+		}
+	}
+}


### PR DESCRIPTION
This event should make giving exp points to players much simpler.
See #702.

### Documentation:

> ## Give experience: `xp`
> 
> Gives the specified amount of experience points to the player. If you want to give whole levels to a player add the `level` argument.
> 
> **Example:** `xp 4 level`