### PR TITLE
Updated for Shopkeepers v2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,10 @@
 			<id>dmulloy2-repo</id>
 			<url>http://repo.dmulloy2.net/nexus/repository/public/</url>
 		</repository>
+		<repository>
+			<id>shopkeepers-releases</id>
+			<url>http://nexus3.cube-nation.de/repository/releases</url>
+		</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -207,8 +211,8 @@
 		</dependency>
 		<dependency>
 			<groupId>com.nisovin.shopkeepers</groupId>
-			<artifactId>Shopkeepers</artifactId>
-			<version>1.74</version>
+			<artifactId>ShopkeepersAPI</artifactId>
+			<version>2.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>me.clip</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,9 @@
 		<repository>
 			<id>shopkeepers-releases</id>
 			<url>http://nexus3.cube-nation.de/repository/releases</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 	<dependencies>

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/Compatibility.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/Compatibility.java
@@ -95,7 +95,10 @@ public class Compatibility implements Listener {
             try {
                 integrator.hook();
                 hooked.add(name);
-            } catch (Exception e) {
+            } catch (UnsupportedVersionException e) {
+            	Debug.error("Could not hook into " + name + ":");
+            	Debug.error(e.getMessage());
+			} catch (Exception e) {
                 Debug.error(String.format("There was an error while hooking into %s %s"
                         + " (BetonQuest %s, Spigot %s). Please post it on GitHub <"
                         + "https://github.com/Co0sh/BetonQuest/issues>",

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/Integrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/Integrator.java
@@ -28,7 +28,7 @@ public interface Integrator {
     /**
      * Integrate with another plugin.
      */
-    public void hook();
+    public void hook() throws Exception;
     
     /**
      * Reload the plugin integration.

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/UnsupportedVersionException.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/UnsupportedVersionException.java
@@ -1,0 +1,44 @@
+/**
+ * Created on 01.07.2018.
+ *
+ * @author Jonas Blocher
+ */
+package pl.betoncraft.betonquest.compatibility;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Thrown if BetonQuest tries to hook a version of a plugin that is not supported
+ * <p>
+ * Created on 01.07.2018.
+ *
+ * @author Jonas Blocher
+ */
+public class UnsupportedVersionException extends Exception {
+
+    private final String currentVersion;
+    private final String requiredVersion;
+    private final Plugin plugin;
+
+    public UnsupportedVersionException(Plugin plugin, String required) {
+        super(String.format("%s version %s is not supported. Please install version %s!",
+                            plugin.getName(),
+                            plugin.getDescription().getVersion(),
+                            required));
+        this.plugin = plugin;
+        this.currentVersion = plugin.getDescription().getVersion();
+        this.requiredVersion = required;
+    }
+
+    public String getCurrentVersion() {
+        return currentVersion;
+    }
+
+    public String getRequiredVersion() {
+        return requiredVersion;
+    }
+
+    public Plugin getPlugin() {
+        return plugin;
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/HavingShopCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/HavingShopCondition.java
@@ -17,16 +17,15 @@
  */
 package pl.betoncraft.betonquest.compatibility.shopkeepers;
 
-import com.nisovin.shopkeepers.Shopkeeper;
-import com.nisovin.shopkeepers.ShopkeepersPlugin;
-import com.nisovin.shopkeepers.shoptypes.PlayerShopkeeper;
+import com.nisovin.shopkeepers.api.ShopkeepersAPI;
+import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
+import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopkeeper;
 
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
 import pl.betoncraft.betonquest.QuestRuntimeException;
 import pl.betoncraft.betonquest.VariableNumber;
 import pl.betoncraft.betonquest.api.Condition;
-import pl.betoncraft.betonquest.utils.PlayerConverter;
 
 /**
  * Checks if the player owns specified amount of shops.
@@ -43,10 +42,10 @@ public class HavingShopCondition extends Condition {
 	@Override
 	public boolean check(String playerID) throws QuestRuntimeException {
 		int count = amount.getInt(playerID);
-		for (Shopkeeper s : ShopkeepersPlugin.getInstance().getAllShopkeepers()) {
+		for (Shopkeeper s : ShopkeepersAPI.getShopkeeperRegistry().getAllShopkeepers()) {
 			if (s instanceof PlayerShopkeeper) {
 				PlayerShopkeeper ps = (PlayerShopkeeper) s;
-				if (ps.getOwner() != null && PlayerConverter.getID(ps.getOwner()).equals(playerID)) {
+				if (ps.getOwnerUUID() != null && ps.getOwnerUUID().toString().equals(playerID)) {
 					count --;
 					if (count == 0) {
 						return true;

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/HavingShopCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/HavingShopCondition.java
@@ -36,6 +36,7 @@ public class HavingShopCondition extends Condition {
 
 	public HavingShopCondition(Instruction instruction) throws InstructionParseException {
 		super(instruction);
+		persistent = true;
 		amount = instruction.getVarNum();
 	}
 

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/OpenShopEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/OpenShopEvent.java
@@ -19,8 +19,8 @@ package pl.betoncraft.betonquest.compatibility.shopkeepers;
 
 import java.util.UUID;
 
-import com.nisovin.shopkeepers.Shopkeeper;
-import com.nisovin.shopkeepers.ShopkeepersPlugin;
+import com.nisovin.shopkeepers.api.ShopkeepersAPI;
+import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
 
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
@@ -40,7 +40,7 @@ public class OpenShopEvent extends QuestEvent {
 		super(instruction);
 		String string = instruction.next();
 		try {
-			shopkeeper = ShopkeepersPlugin.getInstance().getShopkeeper(UUID.fromString(string));
+			shopkeeper = ShopkeepersAPI.getShopkeeperRegistry().getShopkeeperByUniqueId(UUID.fromString(string));
 		} catch (IllegalArgumentException e) {
 			throw new InstructionParseException("Could not parse UUID: '" + string + "'");
 		}

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/ShopkeepersIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/shopkeepers/ShopkeepersIntegrator.java
@@ -17,8 +17,12 @@
  */
 package pl.betoncraft.betonquest.compatibility.shopkeepers;
 
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.compatibility.Integrator;
+import pl.betoncraft.betonquest.compatibility.UnsupportedVersionException;
 
 
 public class ShopkeepersIntegrator implements Integrator {
@@ -30,7 +34,10 @@ public class ShopkeepersIntegrator implements Integrator {
     }
 
     @Override
-    public void hook() {
+    public void hook() throws Exception {
+        Plugin shopkeepers = Bukkit.getPluginManager().getPlugin("Shopkeepers");
+        if (shopkeepers.getDescription().getVersion().startsWith("1."))
+            throw new UnsupportedVersionException(shopkeepers, "2.2.0");
         plugin.registerEvents("shopkeeper", OpenShopEvent.class);
         plugin.registerConditions("shopamount", HavingShopCondition.class);
     }


### PR DESCRIPTION
Added shopkeepers' repository and updated the dependency to use
shopkeepers' API of v2.2.0.

Updated all changed imports (these changes were not backwards
compatible).

Changed: HavingShopCondition now compares owner uuids directly. Previously it would only be able to count the shops for players that are currently online (might have been no issue though, if those conditions are always only getting checked for online players anyways, not sure about that).