### PR TITLE
Add %citizen% variable for when hooking into Citizens.

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
@@ -51,6 +51,7 @@ public class CitizensIntegrator implements Integrator {
         plugin.registerEvents("movenpc", NPCMoveEvent.class);
         plugin.registerConversationIO("chest", CitizensInventoryConvIO.class);
         plugin.registerConversationIO("combined", CitizensInventoryConvIO.CitizensCombined.class);
+        plugin.registerVariable("citizen", CitizensVariable.class);
     }
 
     @Override

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
@@ -1,0 +1,88 @@
+/**
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.betoncraft.betonquest.compatibility.citizens;
+
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Location;
+import pl.betoncraft.betonquest.Instruction;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.api.Variable;
+
+/**
+ * Provides information about a citizen npc.
+ *
+ * Format:
+ *   %citizen.<id>.<key>%
+ *
+ * Keys:
+ *   * name - (default) Return citizen name
+ *   * location  - Return citizen location. x;y;z;world;yaw;pitch
+ */
+public class CitizensVariable extends Variable {
+
+	private int id;
+	private String key;
+
+	public CitizensVariable(Instruction instruction) throws InstructionParseException {
+		super(instruction);
+
+		String [] parts = instruction.getInstruction().split("\\.");
+		if (parts.length < 2) {
+			throw new InstructionParseException("Invalid variable format");
+		}
+
+		try {
+			id = Integer.parseInt(parts[1]);
+		} catch (NumberFormatException ex) {
+			throw new InstructionParseException("Invalid NPC ID: " + parts[1]);
+		}
+
+		// Accept any key. We return blank if its invalid to support forward compatibility
+		key = parts[2];
+	}
+
+	@Override
+	public String getValue(String playerID) {
+		NPC npc = CitizensAPI.getNPCRegistry().getById(id);
+		if (npc == null) {
+			return "";
+		}
+
+		switch(key) {
+			case "name":
+				return npc.getName();
+			case "full_name":
+				return npc.getFullName();
+			case "location":
+				if (npc.getEntity() != null) {
+					Location loc = npc.getEntity().getLocation();
+					return String.format("%.2f;%.2f;%.2f;%s;%.2f;%.2f",
+							loc.getX(),
+							loc.getY(),
+							loc.getZ(),
+							loc.getWorld().getName(),
+							loc.getYaw(),
+							loc.getPitch());
+				}
+				break;
+		}
+		return "";
+	}
+
+}

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
@@ -43,7 +43,7 @@ public class CitizensVariable extends Variable {
 	public CitizensVariable(Instruction instruction) throws InstructionParseException {
 		super(instruction);
 
-		id = instruction.getPositive();
+		id = instruction.getInt();
 		try {
 			key = TYPE.valueOf(instruction.next().toUpperCase());
 		} catch (IllegalArgumentException e) {
@@ -55,7 +55,7 @@ public class CitizensVariable extends Variable {
 	public String getValue(String playerID) {
 		NPC npc = CitizensAPI.getNPCRegistry().getById(id);
 		if (npc == null) {
-			return null;
+			return "";
 		}
 
 		switch(key) {
@@ -76,7 +76,7 @@ public class CitizensVariable extends Variable {
 				}
 				break;
 		}
-		return null;
+		return "";
 	}
 
 	private enum TYPE {

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
@@ -28,48 +28,42 @@ import pl.betoncraft.betonquest.api.Variable;
  * Provides information about a citizen npc.
  *
  * Format:
- *   %citizen.<id>.<key>%
+ *   %citizen.<id>[.<type>]%
  *
- * Keys:
+ * Types:
  *   * name - (default) Return citizen name
+ *   * full_name - Full Citizen name
  *   * location  - Return citizen location. x;y;z;world;yaw;pitch
  */
 public class CitizensVariable extends Variable {
 
 	private int id;
-	private String key;
+	private TYPE key;
 
 	public CitizensVariable(Instruction instruction) throws InstructionParseException {
 		super(instruction);
 
-		String [] parts = instruction.getInstruction().split("\\.");
-		if (parts.length < 2) {
-			throw new InstructionParseException("Invalid variable format");
-		}
-
+		id = instruction.getPositive();
 		try {
-			id = Integer.parseInt(parts[1]);
-		} catch (NumberFormatException ex) {
-			throw new InstructionParseException("Invalid NPC ID: " + parts[1]);
+			key = TYPE.valueOf(instruction.next().toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new InstructionParseException("Invalid Type: " + instruction.current());
 		}
-
-		// Accept any key. We return blank if its invalid to support forward compatibility
-		key = parts[2];
 	}
 
 	@Override
 	public String getValue(String playerID) {
 		NPC npc = CitizensAPI.getNPCRegistry().getById(id);
 		if (npc == null) {
-			return "";
+			return null;
 		}
 
 		switch(key) {
-			case "name":
+			case NAME:
 				return npc.getName();
-			case "full_name":
+			case FULL_NAME:
 				return npc.getFullName();
-			case "location":
+			case LOCATION:
 				if (npc.getEntity() != null) {
 					Location loc = npc.getEntity().getLocation();
 					return String.format("%.2f;%.2f;%.2f;%s;%.2f;%.2f",
@@ -82,7 +76,13 @@ public class CitizensVariable extends Variable {
 				}
 				break;
 		}
-		return "";
+		return null;
+	}
+
+	private enum TYPE {
+		NAME,
+		FULL_NAME,
+		LOCATION
 	}
 
 }

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensVariable.java
@@ -28,10 +28,10 @@ import pl.betoncraft.betonquest.api.Variable;
  * Provides information about a citizen npc.
  *
  * Format:
- *   %citizen.<id>[.<type>]%
+ *   {@code %citizen.<id>.<type>%}
  *
  * Types:
- *   * name - (default) Return citizen name
+ *   * name - Return citizen name
  *   * full_name - Full Citizen name
  *   * location  - Return citizen location. x;y;z;world;yaw;pitch
  */


### PR DESCRIPTION
# Citizen Variable

I wanted to obtain the location of a citizen (for example to trigger an objective when a player is near a citizen who may be wandering around).

This provides a %citizen% variable with the following format:
  %citizen.{npcId}.{key}

Where:
  * npcId - The ID of the citizen
  * key - The data item we are interested in.  

Key:
  * name -  Name of Citizen
  * full_name - Full name of Citizen
  * location - Location of Citizen (x;y;z;world;yaw;pitch)

# Example
In objective.yml:
```
near_npc: 'location %citizen.27.location% 5 events:e_tag_been_near global'
```
