### PR TITLE
Implement Hologram Items and NPC Holograms

### DIFF
--- a/docs/Compatibility.md
+++ b/docs/Compatibility.md
@@ -316,11 +316,41 @@ In order to create a hologram, you have to add `holograms` section in your _cust
       beton:
         lines:
         - '&bThis is Beton.'
+        - 'item:MAP'
         - '&eBeton is strong.'
         location: 100;200;300;world
         conditions: has_some_quest, !finished_some_quest
 
+A line can also represent a floating item. To do so enter the line as 'item:`MATERIAL`'. It will be replaced with the `MATERIAL` defined. In the above example, a floating map will be seen between two lines of text.
+
 The holograms are updated every 10 seconds. If you want to make it faster, add `hologram_update_interval` option in _config.yml_ file and set it to a number of ticks you want to pass between updates (one second is 20 ticks). Don't set it to 0 or negative numbers, it will result in an error.
+
+If Citizens is also installed then you can have holograms configured relative to an npc. Add the following to _custom.yml_.
+
+    npc_holograms:
+      # How often to check conditions
+      check_interval: 100
+
+      # Disable npc_holograms
+      disabled: false
+
+      # Hologram Settings
+      default:
+        # Lines in hologram
+        lines:
+          - !
+        # Vector offset to NPC position to place hologram
+        vector: 0;3;0
+
+        # Conditions to display hologram
+        conditions: has_some_quest, !finished_some_quest
+
+        # NPC's to apply these settings to. If blank, applies by default
+        npcs:
+          - 0
+          - 22
+
+Item lines are also supported here.
 
 ## [RacesAndClasses](http://dev.bukkit.org/bukkit-plugins/racesandclasses/)
 

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -1,0 +1,319 @@
+/**
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.betoncraft.betonquest.compatibility.citizens;
+
+import com.gmail.filoghost.holographicdisplays.api.Hologram;
+import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.ConditionID;
+import pl.betoncraft.betonquest.ObjectNotFoundException;
+import pl.betoncraft.betonquest.config.Config;
+import pl.betoncraft.betonquest.config.ConfigPackage;
+import pl.betoncraft.betonquest.utils.Debug;
+import pl.betoncraft.betonquest.utils.PlayerConverter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Displays a hologram relative to an npc
+ *
+ * Some care is taken to optimize how holograms are displayed. They are destroyed when not needed, shared between players and
+ * we only have a fast update when needed to ensure they are relative to the NPC position
+ *
+ */
+
+public class CitizensHologram extends BukkitRunnable implements Listener {
+
+    private static CitizensHologram instance;
+
+    // All NPC's with config
+    private Map<NPC, List<NPCHologram>> npcs = new HashMap<>();
+
+    private int interval;
+    private int tick = 0;
+    private boolean enabled = false;
+
+    // Updater
+    private BukkitRunnable updater;
+
+    private class NPCHologram {
+        HologramConfig config;
+        Hologram hologram;
+    }
+
+    private class HologramConfig {
+        private List<ConditionID> conditions;
+        private Vector vector;
+        private ConfigurationSection settings;
+
+    }
+
+
+    public CitizensHologram() {
+        instance = this;
+
+        // Start this when all plugins loaded
+        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(BetonQuest.getInstance(), new Runnable() {
+            @Override
+            public void run() {
+                // loop across all packages
+                for (ConfigPackage pack : Config.getPackages().values()) {
+
+                    // load all NPC's
+                    for (String npcID : pack.getMain().getConfig().getConfigurationSection("npcs").getKeys(false)) {
+                        try {
+                            NPC npc = CitizensAPI.getNPCRegistry().getById(Integer.parseInt(npcID));
+                            if (npc != null) {
+                                npcs.put(npc, new ArrayList<>());
+                            }
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+
+                    // npc_holograms contains all holograms for NPCs
+                    ConfigurationSection section = pack.getCustom().getConfig().getConfigurationSection("npc_holograms");
+
+                    // if it's not defined then we're not displaying holograms
+                    if (section == null) {
+                        continue;
+                    }
+                    // there's a setting to disable npc holograms altogether
+                    if ("true".equalsIgnoreCase(section.getString("disabled"))) {
+                        return;
+                    }
+
+                    // load the condition check interval
+                    interval = section.getInt("check_interval", 100);
+                    if (interval <= 0) {
+                        Debug.error("Could not load npc holograms of package " + pack.getName() + ": " +
+                                "Check interval must be bigger than 0.");
+                        return;
+                    }
+
+                    // loading hologram config
+                    for (String key : section.getKeys(false)) {
+                        ConfigurationSection settings = section.getConfigurationSection(key);
+
+                        // if the key is not a configuration section then it's not a hologram
+                        if (settings == null) {
+                            continue;
+                        }
+
+                        HologramConfig hologramConfig = new HologramConfig();
+
+                        try {
+                            String vectorParts[] = settings.getString("vector", "0;3;0").split(";");
+                            hologramConfig.vector = new Vector(
+                                    Double.parseDouble(vectorParts[0]),
+                                    Double.parseDouble(vectorParts[1]),
+                                    Double.parseDouble(vectorParts[2])
+                            );
+                        } catch (NumberFormatException e) {
+                            Debug.error(pack.getName() + ": Invalid vector: " + settings.getString("vector"));
+                            continue;
+                        }
+
+                        // load all conditions
+                        hologramConfig.conditions = new ArrayList<>();
+                        String rawConditions = settings.getString("conditions");
+                        if (rawConditions != null) {
+                            for (String part : rawConditions.split(",")) {
+                                try {
+                                    hologramConfig.conditions.add(new ConditionID(pack, part));
+                                } catch (ObjectNotFoundException e) {
+                                    Debug.error("Error while loading " + part + " condition for hologram " + pack.getName() + "."
+                                            + key + ": " + e.getMessage());
+                                }
+                            }
+                        }
+
+                        hologramConfig.settings = settings;
+
+                        // load all NPCs for which this effect can be displayed
+                        List<NPC> affectedNpcs = new ArrayList<>();
+                        for (int id : settings.getIntegerList("npcs")) {
+                            NPC npc = CitizensAPI.getNPCRegistry().getById(id);
+                            if (npc != null) {
+                                affectedNpcs.add(npc);
+                            }
+                        }
+
+                        for (NPC npc : affectedNpcs.isEmpty()?npcs.keySet():affectedNpcs) {
+                            NPCHologram npcHologram = new NPCHologram();
+                            npcHologram.config = hologramConfig;
+                            npcs.get(npc).add(npcHologram);
+                        }
+
+                    }
+                }
+
+                Bukkit.getPluginManager().registerEvents(instance, BetonQuest.getInstance());
+                runTaskTimer(BetonQuest.getInstance(), 1, interval);
+            }
+        }, 3);
+
+
+        enabled = true;
+    }
+
+    /**
+     * Reloads the particle effect
+     */
+    public static void reload() {
+        if (instance.enabled) {
+            instance.cleanUp();
+
+            instance.cancel();
+        }
+        new CitizensHologram();
+    }
+
+    @Override
+    public void run() {
+        updateHolograms();
+    }
+
+    private void cleanUp() {
+        // Cancel Updater
+        if (updater != null) {
+            updater.cancel();
+            updater = null;
+        }
+
+        // Destroy all holograms
+        for (NPC npc : npcs.keySet()) {
+            for (NPCHologram npcHologram : npcs.get(npc)) {
+                if (npcHologram.hologram != null) {
+                    npcHologram.hologram.delete();
+                    npcHologram.hologram = null;
+                }
+            }
+        }
+    }
+
+    private void updateHolograms() {
+        // If we need to update hologram positions
+        boolean npcUpdater = false;
+
+        // Handle updating each NPC
+        for (NPC npc : npcs.keySet()) {
+            for (NPCHologram npcHologram : npcs.get(npc)) {
+                boolean hologramEnabled = false;
+
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    boolean visible = true;
+
+                    for (ConditionID condition : npcHologram.config.conditions) {
+                        if (!BetonQuest.condition(PlayerConverter.getID(player), condition)) {
+                            visible = false;
+                            break;
+                        }
+                    }
+
+                    if (visible) {
+                        hologramEnabled = true;
+                        if (npcHologram.hologram == null) {
+                            Hologram hologram = HologramsAPI.createHologram(BetonQuest.getInstance(), npc.getStoredLocation().add(npcHologram.config.vector));
+                            hologram.getVisibilityManager().setVisibleByDefault(false);
+                            for (String line : npcHologram.config.settings.getStringList("lines")) {
+                                if (line.startsWith("item:")) {
+                                    hologram.appendItemLine(new ItemStack(Material.matchMaterial(line.substring(5))));
+                                } else {
+                                    hologram.appendTextLine(line.replace('&', '§'));
+                                }
+                            }
+                            npcHologram.hologram = hologram;
+                        }
+
+                        // We do this a tick later to work around a bug where holograms simply don't appear
+                        Bukkit.getServer().getScheduler().runTaskLaterAsynchronously(BetonQuest.getInstance(), new Runnable() {
+                            @Override
+                            public void run() {
+                                if (npcHologram.hologram != null) {
+                                    npcHologram.hologram.getVisibilityManager().showTo(player);
+                                }
+                            }
+                        },2);
+
+                    } else {
+                        if (npcHologram.hologram != null) {
+                            Bukkit.getServer().getScheduler().runTaskLaterAsynchronously(BetonQuest.getInstance(), new Runnable() {
+                                @Override
+                                public void run() {
+                                    if (npcHologram.hologram != null) {
+                                        npcHologram.hologram.getVisibilityManager().hideTo(player);
+                                    }
+                                }
+                            },2);
+                        }
+                    }
+                }
+
+                if (hologramEnabled) {
+                    npcUpdater = true;
+                } else {
+                    // Destroy hologram
+                    if (npcHologram.hologram != null) {
+
+                        npcHologram.hologram.delete();
+                        npcHologram.hologram = null;
+                    }
+                }
+            }
+
+        }
+
+        if (npcUpdater) {
+            if (updater == null) {
+                // The updater only runs when at least one hologram is visible to ensure it stays relative to npc location
+                updater = new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        for (NPC npc : npcs.keySet()) {
+                            for (NPCHologram npcHologram : npcs.get(npc)) {
+                                if (npcHologram.hologram != null) {
+                                    npcHologram.hologram.teleport(npc.getStoredLocation().add(npcHologram.config.vector));
+                                }
+                            }
+
+                        }
+                    }
+                };
+                updater.runTaskTimer(BetonQuest.getInstance(), 1L, 1L);
+            }
+        } else {
+            if (updater != null) {
+                updater.cancel();
+                updater = null;
+            }
+        }
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
@@ -41,6 +41,11 @@ public class CitizensIntegrator implements Integrator {
         if (Compatibility.getHooked().contains("EffectLib"))
             new CitizensParticle();
 
+        // if HolographicAPI is hooked, start CitizensHologram
+        if (Compatibility.getHooked().contains("HolographicDisplays")) {
+            new CitizensHologram();
+        }
+
         // if ProtocolLib is hooked, start NPCHider
         if (Compatibility.getHooked().contains("ProtocolLib")) {
             NPCHider.start();
@@ -64,6 +69,7 @@ public class CitizensIntegrator implements Integrator {
     public void reload() {
         if (Compatibility.getHooked().containsAll(Arrays.asList("Citizens", "EffectLib"))) {
             CitizensParticle.reload();
+            CitizensHologram.reload();
         }
     }
 

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensIntegrator.java
@@ -69,6 +69,9 @@ public class CitizensIntegrator implements Integrator {
     public void reload() {
         if (Compatibility.getHooked().containsAll(Arrays.asList("Citizens", "EffectLib"))) {
             CitizensParticle.reload();
+        }
+
+        if (Compatibility.getHooked().containsAll(Arrays.asList("Citizens", "HolographicDisplays"))) {
             CitizensHologram.reload();
         }
     }

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -23,8 +23,10 @@ import java.util.Map.Entry;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
@@ -97,7 +99,12 @@ public class HologramLoop {
 				Hologram hologram = HologramsAPI.createHologram(BetonQuest.getInstance(), location);
 				hologram.getVisibilityManager().setVisibleByDefault(false);
 				for (String line : lines) {
-					hologram.appendTextLine(line.replace('&', '§'));
+					// If line begins with 'item:', then we will assume its a floating item
+					if (line.startsWith("item:")) {
+						hologram.appendItemLine(new ItemStack(Material.matchMaterial(line.substring(5))));
+					} else {
+						hologram.appendTextLine(line.replace('&', '§'));
+					}
 				}
 				holograms.put(hologram, conditions);
 			}

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HolographicDisplaysIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HolographicDisplaysIntegrator.java
@@ -17,7 +17,9 @@
  */
 package pl.betoncraft.betonquest.compatibility.holographicdisplays;
 
+import pl.betoncraft.betonquest.compatibility.Compatibility;
 import pl.betoncraft.betonquest.compatibility.Integrator;
+import pl.betoncraft.betonquest.compatibility.citizens.CitizensHologram;
 
 
 public class HolographicDisplaysIntegrator implements Integrator {
@@ -27,6 +29,11 @@ public class HolographicDisplaysIntegrator implements Integrator {
     
     public HolographicDisplaysIntegrator() {
         instance = this;
+
+        // if HolographicAPI is hooked, start CitizensHologram
+        if (Compatibility.getHooked().contains("Citizens")) {
+            new CitizensHologram();
+        }
     }
 
     @Override


### PR DESCRIPTION
# Information
Provide the ability to have Items in a holograms and NPC Holograms. 

## Holographic Items

Example:

```
    holograms:
      beton:
        lines:
        - '&bThis is Beton.'
        - 'item:MAP'
        - '&eBeton is strong.'
        location: 100;200;300;world
        conditions: has_some_quest, !finished_some_quest
```

This provides two lines of text, with a floating map between them.

## NPC Holograms
An NPC hologram provides one or more holograms that are shown relative to an NPC position, much like the EffectLib option. Care is taken to ensure resources are minimized. ProtocolLib should be available to ensure players only see holograms meant for them. Holograms will follow NPC's as they move around.

This is done by adding something like the following to custom.yml:

```YML
    npc_holograms:
      # How often to check conditions
      check_interval: 100

      # Disable npc_holograms
      disabled: false

      # Hologram Settings
      default:
        # Lines in hologram
        lines:
          - item:MAP
        # Vector offset to NPC position to place hologram
        vector: 0;3;0

        # Conditions to display hologram
        conditions: has_some_quest, !finished_some_quest

        # NPC's to apply these settings to. If blank, applies by default
        npcs:
          - 0
          - 22
```    
An example image: https://i.imgur.com/viUUP5f.mp4

Lines can contain both text and items.

# Changes:
  * Update HolographicAPI compatability so that a line that contains 'item:material_name' will be replaced with the material
  * Update Documentation
  * Support npc_holograms in custom.yml
  * Care is taken that holograms only exist whilst at least 1 player has conditions to view it otherwise it is removed.
  * Holograms will follow NPC's as they move
  * Provide a cleanup routine to destroy holograms when BQ is reloaded
