### PR TITLE
Implement SlowTellrawConvIO

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -75,7 +75,7 @@ You can also translate journal entries, quest cancelers and `message` events, mo
 
 ### Conversation displaying
 
-By default BetonQuest uses the most native and safe way of displaying a conversation, which is the Minecraft chat. You choose the option by typing their number in. You can however change it with `default_conversation_IO` option in _config.yml_ file. Default value is `simple`. By changing it to `tellraw` you will add a possibility to click on options. Keep in mind that if the chat is quickly flowing, players will sometimes "miss" an option and click another one. There is a display type that doesn't suffer from this problem at all, it's called `chest`. It will display the conversation in an inventory GUI, where the NPC's text and options will be shown as item lore.
+By default BetonQuest uses the most native and safe way of displaying a conversation, which is the Minecraft chat. You choose the option by typing their number in. You can however change it with `default_conversation_IO` option in _config.yml_ file. Default value is `simple`. By changing it to `tellraw` you will add a possibility to click on options. Keep in mind that if the chat is quickly flowing, players will sometimes "miss" an option and click another one. There is a display type that doesn't suffer from this problem at all, it's called `chest`. It will display the conversation in an inventory GUI, where the NPC's text and options will be shown as item lore. Alternatively use `slowtellraw` which provides the npc responses line by line delayed by 0.5 seconds.
 
 You can control the colors of conversation elements in the _config.yml_ file, in `conversation_colors` section. Here you must use names of the colors.
 

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -88,16 +88,7 @@ import pl.betoncraft.betonquest.conditions.WorldCondition;
 import pl.betoncraft.betonquest.config.Config;
 import pl.betoncraft.betonquest.config.ConfigPackage;
 import pl.betoncraft.betonquest.config.ConfigUpdater;
-import pl.betoncraft.betonquest.conversation.CombatTagger;
-import pl.betoncraft.betonquest.conversation.Conversation;
-import pl.betoncraft.betonquest.conversation.ConversationColors;
-import pl.betoncraft.betonquest.conversation.ConversationData;
-import pl.betoncraft.betonquest.conversation.ConversationIO;
-import pl.betoncraft.betonquest.conversation.ConversationResumer;
-import pl.betoncraft.betonquest.conversation.CubeNPCListener;
-import pl.betoncraft.betonquest.conversation.InventoryConvIO;
-import pl.betoncraft.betonquest.conversation.SimpleConvIO;
-import pl.betoncraft.betonquest.conversation.TellrawConvIO;
+import pl.betoncraft.betonquest.conversation.*;
 import pl.betoncraft.betonquest.database.Database;
 import pl.betoncraft.betonquest.database.GlobalData;
 import pl.betoncraft.betonquest.database.MySQL;
@@ -428,6 +419,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerConversationIO("tellraw", TellrawConvIO.class);
 		registerConversationIO("chest", InventoryConvIO.class);
 		registerConversationIO("combined", InventoryConvIO.Combined.class);
+		registerConversationIO("slowtellraw", SlowTellrawConvIO.class);
 
 		// register variable types
 		registerVariable("player", PlayerNameVariable.class);

--- a/src/main/java/pl/betoncraft/betonquest/config/Config.java
+++ b/src/main/java/pl/betoncraft/betonquest/config/Config.java
@@ -293,6 +293,7 @@ public class Config {
 		return getMessage(lang, message, null);
 	}
 
+
 	/**
 	 * @return the map of packages and their names
 	 */
@@ -304,7 +305,7 @@ public class Config {
 	 * Retrieves the string from across all configuration. The variables are not
 	 * replaced! To replace variables automatically just call getString() method
 	 * on ConfigPackage.
-	 * 
+	 *
 	 * @param address
 	 *            address of the string
 	 * @return the requested string
@@ -330,7 +331,7 @@ public class Config {
 
 	/**
 	 * Sets the string at specified address
-	 * 
+	 *
 	 * @param address
 	 *            address of the variable
 	 * @param value
@@ -378,7 +379,7 @@ public class Config {
 	 * Returns the ID of a conversation assigned to specified NPC, across all
 	 * packages. If there are multiple assignments for the same value, the first
 	 * one will be returned.
-	 * 
+	 *
 	 * @param value
 	 *            the name of the NPC (as defined in <i>main.yml</i>)
 	 * @return the ID of the conversation assigned to this NPC or null if there
@@ -401,7 +402,7 @@ public class Config {
 	/**
 	 * Sends a message to player in his chosen language or default or English
 	 * (if previous not found).
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param messageName
@@ -415,7 +416,7 @@ public class Config {
 	 * Sends a message to player in his chosen language or default or English
 	 * (if previous not found). It will replace all {x} sequences with the
 	 * variables.
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param messageName
@@ -431,7 +432,7 @@ public class Config {
 	 * Sends a message to player in his chosen language or default or English
 	 * (if previous not found). It will replace all {x} sequences with the
 	 * variables and play the sound.
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param messageName
@@ -449,7 +450,7 @@ public class Config {
 	 * Sends a message to player in his chosen language or default or English
 	 * (if previous not found). It will replace all {x} sequences with the
 	 * variables and play the sound. It will also add a prefix to the message.
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param messageName
@@ -465,25 +466,53 @@ public class Config {
 	 */
 	public static void sendMessage(String playerID, String messageName, String[] variables, String soundName,
 			String prefixName, String[] prefixVariables) {
+		String message = parseMessage(playerID, messageName, variables, prefixName, prefixVariables);
+		if (message == null || message.length() == 0)
+			return;
+
+		Player player = PlayerConverter.getPlayer(playerID);
+		player.sendMessage(message);
+		if (soundName != null) {
+			playSound(playerID, soundName);
+		}
+	}
+
+	public static String parseMessage(String playerID, String messageName, String[] variables) {
+		return parseMessage(playerID, messageName, variables, null, null);
+	}
+
+	/**
+	 * Retrieve's a message in the language of the player, replacing variables
+	 * @param playerID
+	 * 			name of the player
+	 * @param messageName
+	 * 			name of the message to retrieve
+	 * @param variables
+	 * 			Variables to replace in message
+	 * @param prefixName
+	 *            ID of the prefix
+	 * @param prefixVariables
+	 *            array of variables which will be inserted into the prefix
+	 */
+	public static String parseMessage(String playerID, String messageName, String[] variables, String prefixName,
+									String[] prefixVariables) {
 		Player player = PlayerConverter.getPlayer(playerID);
 		PlayerData playerData = BetonQuest.getInstance().getPlayerData(playerID);
 		if (player == null || playerData == null)
-			return;
+			return null;
 		String language = playerData.getLanguage();
 		String message = getMessage(language, messageName, variables);
 		if (message == null || message.length() == 0)
-			return;
+			return null;
 		if (prefixName != null) {
 			String prefix = getMessage(language, prefixName, prefixVariables);
 			if (prefix.length() > 0) {
 				message = prefix + message;
 			}
 		}
-		player.sendMessage(message);
-		if (soundName != null) {
-			playSound(playerID, soundName);
-		}
+		return message;
 	}
+
 
 	/**
 	 * Plays a sound specified in the plugins config to the player

--- a/src/main/java/pl/betoncraft/betonquest/conversation/ChatConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ChatConvIO.java
@@ -190,4 +190,9 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
 	public void end() {
 		HandlerList.unregisterAll(this);
 	}
+
+	@Override
+	public void print(String message) {
+		player.sendMessage(message);
+	}
 }

--- a/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -281,7 +281,7 @@ public class Conversation implements Listener {
 		//only display status messages if conversationIO allows it
 		if (conv.inOut.printMessages()) {
 			// print message
-			Config.sendMessage(playerID, "conversation_end", new String[]{data.getQuester(language)});
+			conv.inOut.print(Config.parseMessage(playerID, "conversation_end", new String[]{data.getQuester(language)}));
 		}
 		//play conversation end sound
 		Config.playSound(playerID, "end");
@@ -514,8 +514,8 @@ public class Conversation implements Listener {
 				if (conv.inOut.printMessages()) {
 					// print message about starting a conversation only if it
 					// is started, not resumed
-					Config.sendMessage(playerID, "conversation_start", new String[]{data.getQuester(language)}, null,
-									   prefixName, prefixVariables);
+					conv.inOut.print(Config.parseMessage(playerID, "conversation_start", new String[]{data.getQuester(language)},
+							prefixName, prefixVariables));
 				}
 				//play the conversation start sound
 				Config.playSound(playerID,"start");

--- a/src/main/java/pl/betoncraft/betonquest/conversation/ConversationIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ConversationIO.java
@@ -68,4 +68,8 @@ public interface ConversationIO {
 		return true;
 	}
 
+	/**
+	 * Send message through ConversationIO
+	 */
+	default void print(String message) { }
 }

--- a/src/main/java/pl/betoncraft/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/SlowTellrawConvIO.java
@@ -1,0 +1,84 @@
+package pl.betoncraft.betonquest.conversation;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.ChatPaginator;
+import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SlowTellrawConvIO extends TellrawConvIO {
+
+    private String npcTextColor;
+    private List<String> endLines;
+
+    public SlowTellrawConvIO(Conversation conv, String playerID) {
+        super(conv, playerID);
+        StringBuilder string = new StringBuilder();
+        for (ChatColor color : colors.get("text")) {
+            string.append(color);
+        }
+        this.npcTextColor = string.toString();
+
+    }
+
+    @Override
+    public void display() {
+        if (npcText == null && options.isEmpty()) {
+            end();
+            return;
+        }
+
+        // NPC Text
+        List<String> lines = new ArrayList<>(Arrays.asList(ChatPaginator.wordWrap(
+                Utils.multiLineColorCodes(textFormat.replace("%npc%", npcName) + npcText, npcTextColor),
+                ChatPaginator.AVERAGE_CHAT_PAGE_WIDTH-2)));
+
+        endLines = new ArrayList<>();
+
+        new BukkitRunnable(){
+            @Override
+            public void run() {
+                if (lines.size() == 0) {
+                    // Display Options
+                    for (int j = 1; j <= options.size(); j++) {
+                        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(),
+                                "tellraw " + name + " [{\"text\":\"" + number.replace("%number%", Integer.toString(j))
+                                        + "\"},{\"text\":\"" + options.get(j) + "\",\"color\":\"" + color + "\",\"bold\":\"" + bold
+                                        + "\",\"italic\":\"" + italic + "\",\"underlined\":\"" + underline
+                                        + "\",\"strikethrough\":\"" + strikethrough + "\",\"obfuscated\":\"" + magic
+                                        + "\",\"clickEvent\":{\"action\":\"run_command\",\"value\":\"/betonquestanswer "
+                                        + hashes.get(j) + "\"}}]");
+                    }
+
+                    // Display endLines
+                    for(String message : endLines) {
+                        SlowTellrawConvIO.super.print(message);
+                    }
+
+                    endLines = null;
+
+                    this.cancel();
+                    return;
+                }
+
+                player.sendMessage(lines.remove(0));
+            }
+        }.runTaskTimer(BetonQuest.getInstance(), 0, 2);
+    }
+
+    @Override
+    public void print(String message) {
+        if (endLines == null) {
+            super.print(message);
+            return;
+        }
+
+        // If endLines is defined, we add to it to be outputted after we have outputted our previous text
+        endLines.add(message);
+    }
+}

--- a/src/main/java/pl/betoncraft/betonquest/conversation/TellrawConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/TellrawConvIO.java
@@ -32,15 +32,15 @@ import org.bukkit.event.player.PlayerCommandPreprocessEvent;
  */
 public class TellrawConvIO extends ChatConvIO {
 
-	private HashMap<Integer, String> hashes;
+	protected HashMap<Integer, String> hashes;
 	private int count = 0;
-	private String color;
-	private boolean italic;
-	private boolean bold;
-	private boolean underline;
-	private boolean strikethrough;
-	private boolean magic;
-	private String number;
+	protected String color;
+	protected boolean italic;
+	protected boolean bold;
+	protected boolean underline;
+	protected boolean strikethrough;
+	protected boolean magic;
+	protected String number;
 
 	public TellrawConvIO(Conversation conv, String playerID) {
 		super(conv, playerID);


### PR DESCRIPTION
This slows down the npc chat so it doesn't all appear at once but each line is outputted every 2 ticks. Lines are broken with colours honoured. Reset colour is properly reset to conversation colour. 

Some useful fixes to ChatIO are implemented in a backwards compatible way which is why I'm doing a PR here instead of putting this in a separate package.

Changes:
  * Add new conversation IO that extends tellraw
  * Update TellrawConvIO to allow protected access to some variables
  * Register SlowTellrawConvIO as 'slowtellraw'
  * Add print() feature to ConversionIO to allow one to send other messages through the ConversationIO. This is used in slowtellraw to buffer other messages (header/footer of message) but defaults to just outputting so it is backwards compatible. Useful for other ConvIO that want to control this stuff.
  * Update Documentation
