### PR TITLE
Add Configuration for chest convIO

### DIFF
--- a/docs/Installation-and-Configuration.md
+++ b/docs/Installation-and-Configuration.md
@@ -62,6 +62,10 @@ The configuration of BetonQuest is done mainly in _config.yml_ file. All options
     - `option` is the text of an option
 * `date_format` is the Java [date format](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in journal dates. It needs to have a space between the day and hour.
 * `debug` is responsible for logging plugin's activity to _debug.log_ file in _logs_ directory. You shouldn't turn this on as it can slow your server down. However if you experience any errors turn this on, let the plugin gather the data and send logs to the developer. Note that first run of the plugin will be logged anyway, just as a precaution.
+* `conversation_IO_config` manages settings for individual conoversation IO's:
+    - `chest` manages settings for the chest conversation IO
+        - `show_number` will show the player number option if true (default: true)
+        - `show_npc_text` will show the npc text in every player option if true (default: true)
 
 ## Updating
 

--- a/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -24,6 +24,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -66,6 +68,10 @@ public class InventoryConvIO implements Listener, ConversationIO {
 	protected Location loc;
 	protected boolean printMessages = false;
 
+	// Config
+	protected boolean showNumber = true;
+	protected boolean showNPCText = true;
+
 	public InventoryConvIO(Conversation conv, String playerID) {
 		this.conv = conv;
 		this.player = PlayerConverter.getPlayer(playerID);
@@ -101,6 +107,14 @@ public class InventoryConvIO implements Listener, ConversationIO {
 		}
 		answerPrefix = string.toString();
 		loc = player.getLocation();
+
+		// Load config
+		if (BetonQuest.getInstance().getConfig().contains("conversation_IO_config.chest")) {
+			ConfigurationSection config = BetonQuest.getInstance().getConfig().getConfigurationSection("conversation_IO_config.chest");
+			showNumber = config.getBoolean("show_number", true);
+			showNPCText = config.getBoolean("show_npc_text", true);
+		}
+
 		Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance());
 	}
 
@@ -192,15 +206,33 @@ public class InventoryConvIO implements Listener, ConversationIO {
 			ItemStack item = new ItemStack(material);
 			item.setDurability(data);
 			ItemMeta meta = item.getItemMeta();
-			meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
-			ArrayList<String> lines = stringToLines(response, npcTextColor,
-					npcNameColor + npcName + ChatColor.RESET + ": ");
+
 			StringBuilder string = new StringBuilder();
 			for (ChatColor color : ConversationColors.getColors().get("number")) {
 				string.append(color);
 			}
-			lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
-			meta.setLore(lines);
+
+			// If both showNumber and showNPCText is false, we can put the response directly into the display name
+			if (!showNumber && !showNPCText) {
+				meta.setDisplayName(Utils.multiLineColorCodes(string.toString() + "- " + optionColor + option, optionColor));
+			} else {
+				if (showNumber) {
+					meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
+				} else {
+					meta.setDisplayName(" ");
+				}
+
+				ArrayList<String> lines = new ArrayList<>();
+
+				if (showNPCText) {
+					lines.addAll(stringToLines(response, npcTextColor,
+							npcNameColor + npcName + ChatColor.RESET + ": "));
+				}
+
+				lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
+				meta.setLore(lines);
+			}
+
 			item.setItemMeta(meta);
 			buttons[j] = item;
 		}


### PR DESCRIPTION
# Notes:
  * Add the following lines to config.yml to control chest convIO settings. The defaults are shown

```
conversation_IO_config:
  chest:
    show_number: true
    show_npc_text: true
```

  * If both show_number and show_npc_text are false then the player option will be shown in the title of the item.

# Changes:
  * Add 2 new options to config.yml that specify if the chest conversationIO will show the player option number, and if the npc text is shown in each option.
  * Update Documentation

# Closes
Closes #832, closes #561