### PR TITLE
Allow Journal Config + Fix DateGap Issue

### DIFF
--- a/docs/Installation-and-Configuration.md
+++ b/docs/Installation-and-Configuration.md
@@ -48,6 +48,7 @@ The configuration of BetonQuest is done mainly in _config.yml_ file. All options
     - `reversed_order` controls the chronological order of entries in the journal. By default the entries are ordered from newest to oldest. You can reverse it, but it will force players to click through a lot of pages to get to the latest entry.
     - `hide_date` hides the date of each entry. Set it to true if you don't want this functionality.
     - `full_main_page` makes the main page take always a full page. If you display a lot of information you should probably make this true. If you use main page only for small notifications, set it to false, so the entries can follow immediately.
+    - `show_separator` shows a separator between journal entries (default: true). Customize the separator in `messages.yml` with the key `journal_separator`.
 * `journal_colors` controls the colors used in the journal. It takes color codes without the `&` character.
     - `date.day` is a day number
     - `date.hour` is a hour number

--- a/src/main/java/pl/betoncraft/betonquest/Journal.java
+++ b/src/main/java/pl/betoncraft/betonquest/Journal.java
@@ -157,7 +157,7 @@ public class Journal {
 				if (dateParts.length > 1) {
 					hour = "§" + Config.getString("config.journal_colors.date.hour") + dateParts[1];
 				}
-				datePrefix = day + " " + hour;
+				datePrefix = day + " " + hour + "\n";
 			}
 			// get package and name of the pointer
 			String[] parts = pointer.getPointer().split("\\.");
@@ -183,8 +183,7 @@ public class Journal {
 				text = "error";
 			}
 			// add the entry to the list
-			texts.add(datePrefix + "§" + Config.getString("config.journal_colors.text") + "\n"
-							  + text);
+			texts.add(datePrefix + "§" + Config.getString("config.journal_colors.text") + text);
 		}
 	}
 
@@ -331,15 +330,26 @@ public class Journal {
 		List<String> finalList = new ArrayList<>();
 		if (Config.getString("config.journal.one_entry_per_page").equalsIgnoreCase("false")) {
 			String color = Config.getString("config.journal_colors.line");
+			String separator = Config.parseMessage(playerID, "journal_separator", null);
+			if (separator == null) {
+				separator = "---------------";
+			}
+			String line = "\n§" + color + separator + "\n";
+
+			if (Config.getString("config.journal.show_separator") != null &&
+					Config.getString("config.journal.show_separator").equalsIgnoreCase("false")) {
+				line = "\n";
+			}
+
 			StringBuilder stringBuilder = new StringBuilder();
 			for (String entry : getText()) {
-				stringBuilder.append(entry + "\n§" + color + "---------------\n");
+				stringBuilder.append(entry + line);
 			}
 			if (mainPage != null && mainPage.length() > 0) {
 				if (Config.getString("config.journal.full_main_page").equalsIgnoreCase("true")) {
 					finalList.addAll(Utils.pagesFromString(mainPage));
 				} else {
-					stringBuilder.insert(0, mainPage + "\n§" + color + "---------------\n");
+					stringBuilder.insert(0, mainPage + line);
 				}
 			}
 			String wholeString = stringBuilder.toString().trim();


### PR DESCRIPTION
# Notes
  * If date is hidden, then the journal won't leave blank lines
  * Separator can be hidden by setting 'journal.show_separator' to false in main config. Defaults to true
  * Separator can be customized by adding 'journal_separator' to messages.yml. Defaults to "---------------"

# Changes
  * Updated journal to include date fix
  * Updated journal to allow hiding separator and customizing through messages.
  * Updated Documentation.

Closes #818