### PR TITLE
Implement Generic BlockSelector

### DIFF
--- a/docs/Conditions-List.md
+++ b/docs/Conditions-List.md
@@ -148,9 +148,9 @@ This condition will return true if the player has specified entry in his journal
 
 ## Test for block: `testforblock` _persistent_, _static_
 
-This condition is met if the block at specified location matches the given material. First argument is a location, and the second one is material of the block to check against, from [this list](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html). There's also an optional `data:` argument which takes a data value. The condition will require you to click on a block with that data (i.e. wool color). 
+This condition is met if the block at specified location matches the given material. First argument is a location, and the second one is a `block selector`. The older `data:value` parameter is still supported but now deprecated.
 
-**Example**: `testforblock 100;200;300;world STONE data:1`
+**Example**: `testforblock 100;200;300;world STONE:1`
 
 ## Empty inventory slots: `empty`
 
@@ -238,6 +238,6 @@ Checks if the player is looking in the given direction. Valid directions are `UP
 
 ##  Looking at a block: `looking`
 
-Checks if the player is looking at a block with the given location or material. You must specify either `loc:` optional (the location of the block) or `type:` optional (the material of the block). You can also specify both.
+Checks if the player is looking at a block with the given location or material. You must specify either `loc:` optional (the location of the block) or `type:` optional as a `block selector`. You can also specify both.
 
 **Example:** `looking loc:12.0;14.0;-15.0;world type:STONE`

--- a/docs/Objectives-List.md
+++ b/docs/Objectives-List.md
@@ -10,7 +10,7 @@ Location objective contains one property, `location`. It's a string formatted li
 
 ## Block: `block`
 
-To complete this objective player must break or place specified amount of blocks. First argument after name is type of the block and data value after a colon (WOOD:2 means birch wooden planks). You can find possible types at Bukkit reference page there: [material types](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html). Next is amount. It can be more than 0 for placing and less than 0 for destroying. You can also use `notify` keyword to display messages to the player each time he updates amount of blocks, optionally with the notification interval after colon.
+To complete this objective player must break or place specified amount of blocks. First argument after name is a `block selector`. Next is amount. It can be more than 0 for placing and less than 0 for destroying. You can also use `notify` keyword to display messages to the player each time he updates amount of blocks, optionally with the notification interval after colon.
 
 This objective has two properties, `amount` and `left`. Amount is current amount of blocks in the objective, left is amount needed to complete the objective. Note that it may sometimes be negative!
 
@@ -26,7 +26,7 @@ This objective also has two properties, `amount` and `left`. Amount is current a
 
 ## Action: `action`
 
-This objective completes when player clicks on given block type. This can be further limited by location condition and item in hand condition. First argument is type of the click, it can be right, left or any. Next is block type, optionally with data value after colon. You can also specify `loc:` argument, followed by standard location format and `range:` followed by a number (or variable). It will define where the clicked block needs to be, as opposed to "where you must be" in location condition. If you add argument `cancel`, the click will be canceled (chest will not open, button will not be pressed etc.)
+This objective completes when player clicks on given block type. This can be further limited by location condition and item in hand condition. First argument is type of the click, it can be right, left or any. Next is a `block selector`. You can also specify `loc:` argument, followed by standard location format and `range:` followed by a number (or variable). It will define where the clicked block needs to be, as opposed to "where you must be" in location condition. If you add argument `cancel`, the click will be canceled (chest will not open, button will not be pressed etc.)
 
 Action objective contains one property, `location`. It's a string formatted like `X: 100, Y: 200, Z:300`. It does not show the radius.
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -441,3 +441,17 @@ To understand better how it works I will show you an example of `party` event. L
     party_reward: party 50 quest_started cancel_button,teleport_to_dungeon
 
 Now, it means that all players that: are in radius of 50 blocks around the player who pressed the button AND meet `quest_started` condition will receive `cancel_button` and `teleport_to_dungeon` events. The first one will cancel the quest for pressing the button for the others (it's no longer needed), the second one will teleport them somewhere. Now, imagine there is a player on the other side of the world who also meets `quest_started` condition - he won't be teleported into the dungeon, because he was not with the other players (not in 50 blocks range). Now, there were a bunch of other players running around the button, but they didn't meet the `quest_started` condition. They also won't be teleported (they didn't start this quest).
+
+## Block Selectors
+
+When specifying a way of matching a block, a `block selector` is used.
+
+The format of a block selector is: `material:data`
+
+Where:
+  * `material` - What material the block is made of. You can look this up in [this list](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html).
+  * `data` - (optional) A number representing the data of the block. If left out then the selector will match all data types.
+
+Examples:
+  * `LOG` - Matches all LOGS
+  * `LOG:1` - Matches SPRUCE LOGS

--- a/src/main/java/pl/betoncraft/betonquest/Instruction.java
+++ b/src/main/java/pl/betoncraft/betonquest/Instruction.java
@@ -31,6 +31,7 @@ import org.bukkit.potion.PotionType;
 
 import pl.betoncraft.betonquest.config.ConfigPackage;
 import pl.betoncraft.betonquest.item.QuestItem;
+import pl.betoncraft.betonquest.utils.BlockSelector;
 import pl.betoncraft.betonquest.utils.LocationData;
 
 public class Instruction {
@@ -279,7 +280,19 @@ public class Instruction {
 		if(string == null) {
 			return null;
 		}
-		return Material.matchMaterial(string);
+		Material material = Material.matchMaterial(string);
+		if (material == null) {
+			material = Material.matchMaterial(string);
+		}
+		return material;
+	}
+
+	public BlockSelector getBlockSelector() throws InstructionParseException {
+		return getBlockSelector(next());
+	}
+
+	public BlockSelector getBlockSelector(String string) throws InstructionParseException {
+		return new BlockSelector(string);
 	}
 	
 	public EntityType getEntity() throws InstructionParseException {

--- a/src/main/java/pl/betoncraft/betonquest/conditions/LookingAtCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/LookingAtCondition.java
@@ -18,7 +18,6 @@
 package pl.betoncraft.betonquest.conditions;
 
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
@@ -26,6 +25,7 @@ import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
 import pl.betoncraft.betonquest.QuestRuntimeException;
 import pl.betoncraft.betonquest.api.Condition;
+import pl.betoncraft.betonquest.utils.BlockSelector;
 import pl.betoncraft.betonquest.utils.LocationData;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
@@ -39,13 +39,17 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
 public class LookingAtCondition extends Condition {
 
     private final LocationData loc;
-    private final Material type;
+    private final BlockSelector selector;
 
     public LookingAtCondition(Instruction instruction) throws InstructionParseException {
         super(instruction);
         loc = instruction.getLocation(instruction.getOptional("loc"));
-        type = instruction.getMaterial(instruction.getOptional("type"));
-        if (loc == null && type == null) throw new InstructionParseException("You must define either 'loc:' or 'type:' optional");
+        selector = instruction.getBlockSelector(instruction.getOptional("type"));
+        if (loc == null && selector == null) throw new InstructionParseException("You must define either 'loc:' or 'type:' optional");
+
+        if (selector != null && !selector.isValid()) {
+            throw new InstructionParseException("Invalid selector: " + selector.toString());
+        }
     }
 
     @Override
@@ -59,8 +63,8 @@ public class LookingAtCondition extends Condition {
                     || location.getBlockY() != to.getBlockY()
                     || location.getBlockZ() != to.getBlockZ()) return false;
         }
-        if (type != null) {
-            if (type != lookingAt.getType()) return false;
+        if (selector != null) {
+            return selector.match(lookingAt);
         }
         return true;
     }

--- a/src/main/java/pl/betoncraft/betonquest/objectives/BlockObjective.java
+++ b/src/main/java/pl/betoncraft/betonquest/objectives/BlockObjective.java
@@ -30,6 +30,7 @@ import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
 import pl.betoncraft.betonquest.api.Objective;
 import pl.betoncraft.betonquest.config.Config;
+import pl.betoncraft.betonquest.utils.BlockSelector;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
 /**
@@ -41,21 +42,22 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
 @SuppressWarnings("deprecation")
 public class BlockObjective extends Objective implements Listener {
 
-	private final Material material;
-	private final byte data;
 	private final int neededAmount;
 	private final boolean notify;
 	private final int notifyInterval;
+	private final BlockSelector selector;
 
 	public BlockObjective(Instruction instruction) throws InstructionParseException {
 		super(instruction);
 		template = BlockData.class;
-		String[] string = instruction.next().split(":");
-		material = instruction.getMaterial(string[0]);
-		data = string.length > 1 ? instruction.getByte(string[1], (byte) -1) : -1;
+		selector = instruction.getBlockSelector();
 		neededAmount = instruction.getInt();
 		notifyInterval = instruction.getInt(instruction.getOptional("notify"), 1);
 		notify = instruction.hasArgument("notify") || notifyInterval > 1;
+
+		if (selector != null && !selector.isValid()) {
+			throw new InstructionParseException("Invalid selector: " + selector.toString());
+		}
 	}
 
 	@EventHandler
@@ -63,8 +65,7 @@ public class BlockObjective extends Objective implements Listener {
 		String playerID = PlayerConverter.getID(event.getPlayer());
 		// if the player has this objective, the event isn't canceled,
 		// the block is correct and conditions are met
-		if (containsPlayer(playerID) && !event.isCancelled() && event.getBlock().getType().equals(material)
-				&& (data < 0 || event.getBlock().getData() == data) && checkConditions(playerID)) {
+		if (containsPlayer(playerID) && !event.isCancelled() && selector.match(event.getBlock()) && checkConditions(playerID)) {
 			// add the block to the total amount
 			BlockData playerData = (BlockData) dataMap.get(playerID);
 			playerData.add();
@@ -89,8 +90,7 @@ public class BlockObjective extends Objective implements Listener {
 		String playerID = PlayerConverter.getID(event.getPlayer());
 		// if the player has this objective, the event isn't canceled,
 		// the block is correct and conditions are met
-		if (containsPlayer(playerID) && !event.isCancelled() && event.getBlock().getType().equals(material)
-				&& (data < 0 || event.getBlock().getData() == data) && checkConditions(playerID)) {
+		if (containsPlayer(playerID) && !event.isCancelled() && selector.match(event.getBlock()) && checkConditions(playerID)) {
 			// remove the block from the total amount
 			BlockData playerData = (BlockData) dataMap.get(playerID);
 			playerData.remove();

--- a/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/BlockSelector.java
@@ -1,0 +1,80 @@
+package pl.betoncraft.betonquest.utils;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+
+/**
+ * A method of selectinig blocks (pre 1.13 version)
+ *
+ * Block selector format:
+ *   MATERIAL:data
+ *
+ * Where:
+ *   - MATERIAL - The material type.
+ *   - data - optional data type. If left out then it will not be compared against
+ *
+ * Example:
+ *   - LOG - Test against all LOG's
+ *   - LOG:1 - Test only against LOG:1
+ *
+ */
+public class BlockSelector {
+
+    private Integer data;
+    private Material material;
+    private String string;
+
+    public BlockSelector(String string) {
+        String materialName;
+        this.string = string;
+
+        if (string.contains(":")) {
+            String[] parts = string.split(":");
+            materialName = parts[0];
+            try {
+                data = Integer.valueOf(parts[1]);
+            } catch (IllegalArgumentException e) {
+                Debug.error("Invalid data type: " + parts[1]);
+            }
+        } else {
+            materialName = string;
+        }
+
+        material = Material.matchMaterial(materialName);
+    }
+
+    public void setData(int data) {
+        this.data = data;
+    }
+
+    public String asString() {
+        return string;
+    }
+
+    public boolean isValid() {
+        return material != null;
+    }
+
+
+    /**
+     * Return true if material matches our selector. State is ignored
+     */
+    public boolean match(Material material) {
+        return (material == this.material);
+    }
+
+    /**
+     * Return true if block matches our selector
+     * @param block Block to test
+     * @return boolean True if a match occurred
+     */
+    @SuppressWarnings("deprecation")
+    public boolean match(Block block) {
+        if (block.getType() != material) {
+            return false;
+        }
+
+        return data == null || block.getData() == data;
+    }
+
+}


### PR DESCRIPTION
# Notes
  * This is not terribly useful for pre 1.13 but allows a single method of matching blocks (useful anyway) and is required to make the path to 1.13 easier.
  * Selector format is 'material:data' where data is optional and if left out will match any data. This brings everything consistent except for testforblockcondition which presently uses a separate 'data:' flag for matching data. This has been changed so it too will support the selector format but will still support the 'data:' flag to remain backwards compatible, however it is now deprecated and will not be supported when running on a 1.13 server.
  * The 1.13 patch will transform this so it supports the old selector format in pre 1.13 minecraft, and the new 1.13 selector format in 1.13+ minecraft without needing to change anything that references it.
  * A bare material can also be matched to a selector. In this case the data field is ignored as materials do not have data.

# Example of usage
```
BlockSelector selector1 = new BlockSelector("LOG");
BlockSelector selector2 = new BlockSelector("LOG:1");

Block testBlock = getABlockFromSomeWhere();

// Will test if testBlock is any sort of LOG
if (selector1.match(testBlock)) {
  return true;
}

// Will test if testBlock is a spruce log only
if (selector2.match(testBlock)) {
  return true;
}

// Will test if the material LOG matches the selector (true in this case)
if (selector2.match(Material.LOG)) {
  return true;
}
```

# Changes:
  * Add a BlockSelector class. This takes a string of format 'material:data' where data is optional. Blocks can then be matched against the selector.
  * Updated LookingAtCondition, TestForBlockCondition, ActionObjective, BlockObjective to use the BlockSelector
  * Updated TestForBlockCondition to still support data: tag and set it in the selector if used, however the selector format should be preferred.
  * Updated Instruction with a convenience method getBlockSelector that can take from the next Instruction or a provided string.
  * Updated Reference document to document more fully what a block selector is
  * Updated Objectives-List and Conditions-List document to reference Block Selectors.

# References
  * #815 - This will allow wildcards after the 1.13 patch. If wildcards are desired pre 1.13 then it should be easy to implement inside the selector itself
  * #817 - Ditto for this. Post 1.13 wildcards will make the need for tags unneeded

