### PR TITLE
Allow one to directly set a compass target

### DIFF
--- a/docs/Events-List.md
+++ b/docs/Events-List.md
@@ -206,7 +206,7 @@ This event removes all items from a chest at specified location. The only argume
 
 ## Compass: `compass`
 
-When you run this event, the player will be able to select a specified location as a target of his compass. To select the target the player must open his backpack and click on the compass icon. The first argument is either `add` or `del`, and second one is the name of the target, as defined in _main.yml_.
+When you run this event, you can add or remove a compass destination for the player. You may also directly set the players's compass destination as well. When a destination is added the player will be able to select a specified location as a target of his compass. To select the target the player must open his backpack and click on the compass icon. The first argument is `add`,`del` or `set`, and second one is the name of the target, as defined in _main.yml_. Note that if you set a target the player will not automatically have it added to their choices.
 
 The destination must be defined in the _main.yml_ file in `compass` section. You can specify a name for the target in each language or just give a general name, and optionally add a custom item (from _items.yml_) to be displayed in the backpack. Example of a compass target:
 


### PR DESCRIPTION
# Changes
  * Updated compass event so it can take a set parameter
  * It will also now check if its a valid compass target when loading the event
  * Updated documentation to reflect the change.

Closes: #783, #482