### PR TITLE
Bug Fix: Implement a better Chat Paginator + Color Resetter

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/conversation/ChatConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/ChatConvIO.java
@@ -183,7 +183,7 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
 			end();
 			return;
 		}
-		player.sendMessage(Utils.multiLineColorCodes(textFormat.replace("%npc%", npcName) + npcText, npcTextColor));
+        player.sendMessage(Utils.replaceReset(textFormat.replace("%npc%", npcName) + npcText, npcTextColor));
 	}
 
 	@Override
@@ -200,6 +200,8 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
 
 	@Override
 	public void print(String message) {
-		player.sendMessage(message);
-	}
+        if (message != null && message.length() > 0) {
+            player.sendMessage(message);
+        }
+    }
 }

--- a/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -107,13 +107,13 @@ public class InventoryConvIO implements Listener, ConversationIO {
 	@Override
 	public void setNpcResponse(String npcName, String response) {
 		this.npcName = npcName;
-		this.response = Utils.multiLineColorCodes(response, npcTextColor);
+        this.response = Utils.replaceReset(response, npcTextColor);
 	}
 
 	@Override
 	public void addPlayerOption(String option) {
 		i++;
-		options.put(i, Utils.multiLineColorCodes(option, optionColor));
+        options.put(i, Utils.replaceReset(option, optionColor));
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/pl/betoncraft/betonquest/conversation/SlowTellrawConvIO.java
+++ b/src/main/java/pl/betoncraft/betonquest/conversation/SlowTellrawConvIO.java
@@ -1,10 +1,28 @@
+/*
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.betoncraft.betonquest.conversation;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.ChatPaginator;
 import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.utils.LocalChatPaginator;
 import pl.betoncraft.betonquest.utils.Utils;
 
 import java.util.ArrayList;
@@ -34,13 +52,13 @@ public class SlowTellrawConvIO extends TellrawConvIO {
         }
 
         // NPC Text
-        List<String> lines = new ArrayList<>(Arrays.asList(ChatPaginator.wordWrap(
-                Utils.multiLineColorCodes(textFormat.replace("%npc%", npcName) + npcText, npcTextColor),
-                ChatPaginator.AVERAGE_CHAT_PAGE_WIDTH-2)));
+        List<String> lines = new ArrayList<>(Arrays.asList(LocalChatPaginator.wordWrap(
+                Utils.replaceReset(textFormat.replace("%npc%", npcName) + npcText, npcTextColor),
+                60)));
 
         endLines = new ArrayList<>();
 
-        new BukkitRunnable(){
+        new BukkitRunnable() {
             @Override
             public void run() {
                 if (lines.size() == 0) {
@@ -56,7 +74,7 @@ public class SlowTellrawConvIO extends TellrawConvIO {
                     }
 
                     // Display endLines
-                    for(String message : endLines) {
+                    for (String message : endLines) {
                         SlowTellrawConvIO.super.print(message);
                     }
 

--- a/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
@@ -1,0 +1,181 @@
+/*
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.betoncraft.betonquest.utils;
+
+import org.bukkit.ChatColor;
+import org.bukkit.util.ChatPaginator;
+
+import java.awt.font.FontRenderContext;
+import java.awt.geom.AffineTransform;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Provide a slightly more intelligent wordwrap that will return the last last space if required
+ */
+public class LocalChatPaginator extends ChatPaginator {
+
+    /**
+     * Takes a string and returns the last colors that can be copied to a new line
+     */
+    public static String getLastColors(String input) {
+        ChatColor lastColor = null;
+        List<ChatColor> lastFormats = new ArrayList<>();
+
+        int length = input.length();
+
+        for (int index = length - 1; index > -1; --index) {
+            char section = input.charAt(index);
+            if (section == 167 && index < length - 1) {
+                char c = input.charAt(index + 1);
+                ChatColor color = ChatColor.getByChar(c);
+
+                if (color != null) {
+                    if (color.equals(ChatColor.RESET)) {
+                        break;
+                    }
+
+                    if (color.isColor() && lastColor == null) {
+                        lastColor = color;
+                        continue;
+                    }
+
+                    if (color.isFormat() && !lastFormats.contains(color)) {
+                        lastFormats.add(color);
+                    }
+                }
+            }
+        }
+
+        String result = String.join("", lastFormats.stream()
+                .map(ChatColor::toString)
+                .collect(Collectors.toList()));
+
+        if (lastColor != null) {
+            result = lastColor.toString() + result;
+        }
+        return result;
+    }
+
+    /**
+     * Breaks a raw string up into a series of lines. Words are wrapped using
+     * spaces as decimeters and the newline character is respected.
+     *
+     * @param rawString  The raw string to break.
+     * @param lineLength The length of a line of text.
+     * @return An array of word-wrapped lines.
+     */
+    public static String[] wordWrap(String rawString, int lineLength) {
+        FontRenderContext frc = new FontRenderContext(new AffineTransform(), true, true);
+
+
+        // A null string is a single line
+        if (rawString == null) {
+            return new String[]{""};
+        }
+
+        // A string shorter than the lineWidth is a single line
+        if (rawString.length() <= lineLength && !rawString.contains("\n")) {
+            return new String[]{rawString};
+        }
+
+        char[] rawChars = (rawString + ' ').toCharArray(); // add a trailing space to trigger pagination
+        StringBuilder word = new StringBuilder();
+        StringBuilder line = new StringBuilder();
+        List<String> lines = new LinkedList<>();
+        int lineColorChars = 0;
+
+        for (int i = 0; i < rawChars.length; i++) {
+            char c = rawChars[i];
+
+            // skip chat color modifiers
+            if (c == ChatColor.COLOR_CHAR) {
+                word.append(ChatColor.getByChar(rawChars[i + 1]));
+                lineColorChars += 2;
+                i++; // Eat the next character as we have already processed it
+                continue;
+            }
+
+            if (c == ' ' || c == '\n') {
+                if (line.length() == 0 && word.length() > lineLength) { // special case: extremely long word begins a line
+                    lines.addAll(Arrays.asList(word.toString().split("(?<=\\G.{" + lineLength + "})")));
+
+                } else if (line.length() + 1 + word.length() - lineColorChars == lineLength) { // Line exactly the correct length...newline
+                    if (line.length() > 0) {
+                        line.append(' ');
+                    }
+                    line.append(word);
+                    lines.add(line.toString());
+                    line = new StringBuilder();
+                    lineColorChars = 0;
+                } else if (line.length() + 1 + word.length() - lineColorChars > lineLength) { // Line too long...break the line at last space
+                    lines.add(line.toString());
+                    line = new StringBuilder();
+
+                    for (String partialWord : word.toString().split("(?<=\\G.{" + lineLength + "})")) {
+                        if (line.length() > 0) {
+                            lines.add(line.toString());
+                        }
+                        line = new StringBuilder(partialWord);
+                    }
+                    lineColorChars = 0;
+                } else {
+
+                    if (line.length() > 0) {
+                        line.append(' ');
+                    }
+                    line.append(word);
+                }
+                word = new StringBuilder();
+
+                if (c == '\n') { // Newline forces the line to flush
+                    lines.add(line.toString());
+                    line = new StringBuilder();
+                    lineColorChars = 0;
+                }
+            } else {
+                word.append(c);
+            }
+        }
+
+        if (line.length() > 0) { // Only add the last line if there is anything to add
+            lines.add(line.toString());
+        }
+
+        // Iterate over the wrapped lines, applying the last color from one line to the beginning of the next
+        if (lines.get(0).length() == 0 || lines.get(0).charAt(0) != ChatColor.COLOR_CHAR) {
+            lines.set(0, ChatColor.WHITE + lines.get(0));
+        }
+        for (int i = 1; i < lines.size(); i++) {
+            final String pLine = lines.get(i - 1);
+            final String subLine = lines.get(i);
+
+            //char color = pLine.charAt(pLine.lastIndexOf(ChatColor.COLOR_CHAR) + 1);
+            if (subLine.length() == 0 || subLine.charAt(0) != ChatColor.COLOR_CHAR) {
+                lines.set(i, getLastColors(pLine) + subLine);
+            }
+        }
+
+        return lines.toArray(new String[0]);
+    }
+
+}

--- a/src/main/java/pl/betoncraft/betonquest/utils/Utils.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/Utils.java
@@ -432,29 +432,7 @@ public class Utils {
 	}
 	
 	/**
-	 * Copies all color codes before each word, so they are correctly displayed regardless of line breaks.
-	 *
-	 * @param string the string to process
-	 * @param def default color code to use instead of resetting; use null for regular reset code
-	 * @return the colorful string ready to split into multiple lines
-	 */
-	public static String multiLineColorCodes(String string, String def) {
-		StringBuilder builder = new StringBuilder();
-		String[] words = string.split(" ");
-		String lastCodes = "";
-		for (String word : words) {
-			word = lastCodes + word;
-			lastCodes = ChatColor.getLastColors(word);
-			builder.append(word);
-			builder.append(' ');
-		}
-		String result = builder.toString();
-		result = result.replace(ChatColor.RESET.toString(), ChatColor.RESET + def);
-		return result.length() == 0 ? "" : result.substring(0, result.length() - 1);
-	}
-
-	/**
-	 * Copies all color codes before each word, so they are correctly displayed regardless of line breaks and pages.
+	 * Resets any color resets to def. Also ensures any new lines copy the colours and format from the previous line
 	 *
 	 * @param pages multiple pages to process
 	 * @param def   default color code to use instead of resetting; use null for regular reset code
@@ -463,22 +441,22 @@ public class Utils {
 	public static List<String> multiLineColorCodes(List<String> pages, String def) {
 		String lastCodes = "";
 		ListIterator<String> i = pages.listIterator();
-		while (i.hasNext()) {
-			StringBuilder builder = new StringBuilder();
-			String[] words = i.next().split(" ");
-			for (String word : words) {
-				word = lastCodes + word;
-				lastCodes = ChatColor.getLastColors(word);
-				builder.append(word);
-				builder.append(' ');
+        List<String> result = new ArrayList<>();
+
+        while (i.hasNext()) {
+            String line = i.next();
+            result.add(lastCodes + replaceReset(line, def));
+            lastCodes = LocalChatPaginator.getLastColors(line);
 			}
-			i.remove();
-			String result = builder.toString();
-			result = result.replace(ChatColor.RESET.toString(), ChatColor.RESET + def);
-			result = result.length() == 0 ? "" : result.substring(0, result.length() - 1);
-			i.add(result);
-		}
-		return pages;
+
+        return result;
+    }
+
+    /**
+     * Replace resets with colorcode
+     */
+    public static String replaceReset(String string, String color) {
+        return string.replace(ChatColor.RESET.toString(), ChatColor.RESET + color);
 	}
 
 	/**


### PR DESCRIPTION
I discovered a bug in the bukkit ChatPaginator that I thought I worked around but still hit issues in certain edge cases. This should hopefully plug the issue permanently and I'll submit a PR to spigot for the issue.

# Changes
  * Extend the Bukkit ChatPaginator into a LocalChatPaginator to provide one that fixes a bug that occurs in Spigot when \n is present in the text (It does not reset the length of the line and results in unpredictable wrapping)
  * Add new method getLastColors() to ChatPaginator that will copy the last chat color + all the unique chat formats from the submitted line instead of just the last color.
  * Improve the various paginator methods in Utils to make use of these.
  * Split into separate methods the ability to replace reset colors with another color, and the ability to get the last lines colors + formatting.