### PR TITLE
Bug Fix: NPC Hologram fix

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -188,12 +188,14 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
      * Reloads the particle effect
      */
     public static void reload() {
-        if (instance.enabled) {
-            instance.cleanUp();
+        if (instance != null) {
+            if (instance.enabled) {
+                instance.cleanUp();
 
-            instance.cancel();
+                instance.cancel();
+            }
+            new CitizensHologram();
         }
-        new CitizensHologram();
     }
 
     @Override

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HolographicDisplaysIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HolographicDisplaysIntegrator.java
@@ -29,16 +29,16 @@ public class HolographicDisplaysIntegrator implements Integrator {
     
     public HolographicDisplaysIntegrator() {
         instance = this;
-
-        // if HolographicAPI is hooked, start CitizensHologram
-        if (Compatibility.getHooked().contains("Citizens")) {
-            new CitizensHologram();
-        }
     }
 
     @Override
     public void hook() {
         hologramLoop = new HologramLoop();
+
+        // if Citizens is hooked, start CitizensHologram
+        if (Compatibility.getHooked().contains("Citizens")) {
+            new CitizensHologram();
+        }
     }
 
     @Override


### PR DESCRIPTION
Changes:
  * Move the test for Citizen hook from constructor to hook() in holographicDisplays. This works around an issue when the order of plugins is wrong and I mistakenly put the check in the wrong location.

  * Updated Citizens to check for null for edge case