### PR TITLE
Fix npc_hologram bugs

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -161,12 +161,12 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                         List<NPC> affectedNpcs = new ArrayList<>();
                         for (int id : settings.getIntegerList("npcs")) {
                             NPC npc = CitizensAPI.getNPCRegistry().getById(id);
-                            if (npc != null) {
+                            if (npc != null && npcs.containsKey(npc)) {
                                 affectedNpcs.add(npc);
                             }
                         }
 
-                        for (NPC npc : affectedNpcs.isEmpty()?npcs.keySet():affectedNpcs) {
+                        for (NPC npc : settings.getIntegerList("npcs").size() == 0?npcs.keySet():affectedNpcs) {
                             NPCHologram npcHologram = new NPCHologram();
                             npcHologram.config = hologramConfig;
                             npcs.get(npc).add(npcHologram);
@@ -176,11 +176,10 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                 }
 
                 Bukkit.getPluginManager().registerEvents(instance, BetonQuest.getInstance());
-                runTaskTimer(BetonQuest.getInstance(), 1, interval);
             }
         }, 3);
 
-
+        runTaskTimer(BetonQuest.getInstance(), 4, interval);
         enabled = true;
     }
 


### PR DESCRIPTION
# Changes:
  * Bug: Reloading quicker than 3 ticks resulted in a NPE. Fixed by executing runTaskTimer immediately.
  * Bug: If an npc exists but is not registered with BQ then a NPE results if its selected in a hologram npc list. Fixed by only storing npc if it exists at the time.
  * Bug: If an npc list exists but the npcs in it do not, then it is considered a default applied to all npcs due to no npcs in the list. Fixed by checking if a list exists at all and only assigning default if there is no list.
