### PR TITLE
MoonCycle condition

### DIFF
--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -1,17 +1,17 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,28 +19,170 @@ package pl.betoncraft.betonquest;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
-import ch.njol.skript.Metrics;
+import org.bstats.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import pl.betoncraft.betonquest.api.*;
-import pl.betoncraft.betonquest.commands.*;
+import pl.betoncraft.betonquest.api.Condition;
+import pl.betoncraft.betonquest.api.LoadDataEvent;
+import pl.betoncraft.betonquest.api.Objective;
+import pl.betoncraft.betonquest.api.QuestEvent;
+import pl.betoncraft.betonquest.api.Variable;
+import pl.betoncraft.betonquest.commands.BackpackCommand;
+import pl.betoncraft.betonquest.commands.CancelQuestCommand;
+import pl.betoncraft.betonquest.commands.CompassCommand;
+import pl.betoncraft.betonquest.commands.JournalCommand;
+import pl.betoncraft.betonquest.commands.LangCommand;
+import pl.betoncraft.betonquest.commands.QuestCommand;
 import pl.betoncraft.betonquest.compatibility.Compatibility;
-import pl.betoncraft.betonquest.conditions.*;
+import pl.betoncraft.betonquest.conditions.AchievementCondition;
+import pl.betoncraft.betonquest.conditions.AlternativeCondition;
+import pl.betoncraft.betonquest.conditions.ArmorCondition;
+import pl.betoncraft.betonquest.conditions.ArmorRatingCondition;
+import pl.betoncraft.betonquest.conditions.BiomeCondition;
+import pl.betoncraft.betonquest.conditions.CheckCondition;
+import pl.betoncraft.betonquest.conditions.ChestItemCondition;
+import pl.betoncraft.betonquest.conditions.ConjunctionCondition;
+import pl.betoncraft.betonquest.conditions.DayOfWeekCondition;
+import pl.betoncraft.betonquest.conditions.EffectCondition;
+import pl.betoncraft.betonquest.conditions.EmptySlotsCondition;
+import pl.betoncraft.betonquest.conditions.ExperienceCondition;
+import pl.betoncraft.betonquest.conditions.FacingCondition;
+import pl.betoncraft.betonquest.conditions.FlyingCondition;
+import pl.betoncraft.betonquest.conditions.GameModeCondition;
+import pl.betoncraft.betonquest.conditions.GlobalPointCondition;
+import pl.betoncraft.betonquest.conditions.GlobalTagCondition;
+import pl.betoncraft.betonquest.conditions.HandCondition;
+import pl.betoncraft.betonquest.conditions.HealthCondition;
+import pl.betoncraft.betonquest.conditions.HeightCondition;
+import pl.betoncraft.betonquest.conditions.ItemCondition;
+import pl.betoncraft.betonquest.conditions.JournalCondition;
+import pl.betoncraft.betonquest.conditions.LocationCondition;
+import pl.betoncraft.betonquest.conditions.LookingAtCondition;
+import pl.betoncraft.betonquest.conditions.MonstersCondition;
+import pl.betoncraft.betonquest.conditions.MooncycleCondition;
+import pl.betoncraft.betonquest.conditions.ObjectiveCondition;
+import pl.betoncraft.betonquest.conditions.PartialDateCondition;
+import pl.betoncraft.betonquest.conditions.PartyCondition;
+import pl.betoncraft.betonquest.conditions.PermissionCondition;
+import pl.betoncraft.betonquest.conditions.PointCondition;
+import pl.betoncraft.betonquest.conditions.RandomCondition;
+import pl.betoncraft.betonquest.conditions.RealTimeCondition;
+import pl.betoncraft.betonquest.conditions.ScoreboardCondition;
+import pl.betoncraft.betonquest.conditions.SneakCondition;
+import pl.betoncraft.betonquest.conditions.TagCondition;
+import pl.betoncraft.betonquest.conditions.TestForBlockCondition;
+import pl.betoncraft.betonquest.conditions.TimeCondition;
+import pl.betoncraft.betonquest.conditions.VariableCondition;
+import pl.betoncraft.betonquest.conditions.VehicleCondition;
+import pl.betoncraft.betonquest.conditions.WeatherCondition;
+import pl.betoncraft.betonquest.conditions.WorldCondition;
 import pl.betoncraft.betonquest.config.Config;
 import pl.betoncraft.betonquest.config.ConfigPackage;
 import pl.betoncraft.betonquest.config.ConfigUpdater;
-import pl.betoncraft.betonquest.conversation.*;
-import pl.betoncraft.betonquest.database.*;
-import pl.betoncraft.betonquest.events.*;
+import pl.betoncraft.betonquest.conversation.CombatTagger;
+import pl.betoncraft.betonquest.conversation.Conversation;
+import pl.betoncraft.betonquest.conversation.ConversationColors;
+import pl.betoncraft.betonquest.conversation.ConversationData;
+import pl.betoncraft.betonquest.conversation.ConversationIO;
+import pl.betoncraft.betonquest.conversation.ConversationResumer;
+import pl.betoncraft.betonquest.conversation.CubeNPCListener;
+import pl.betoncraft.betonquest.conversation.InventoryConvIO;
+import pl.betoncraft.betonquest.conversation.SimpleConvIO;
+import pl.betoncraft.betonquest.conversation.SlowTellrawConvIO;
+import pl.betoncraft.betonquest.conversation.TellrawConvIO;
+import pl.betoncraft.betonquest.database.Database;
+import pl.betoncraft.betonquest.database.GlobalData;
+import pl.betoncraft.betonquest.database.MySQL;
+import pl.betoncraft.betonquest.database.PlayerData;
+import pl.betoncraft.betonquest.database.SQLite;
+import pl.betoncraft.betonquest.database.Saver;
+import pl.betoncraft.betonquest.events.CancelEvent;
+import pl.betoncraft.betonquest.events.ChestClearEvent;
+import pl.betoncraft.betonquest.events.ChestGiveEvent;
+import pl.betoncraft.betonquest.events.ChestTakeEvent;
+import pl.betoncraft.betonquest.events.ClearEvent;
+import pl.betoncraft.betonquest.events.CommandEvent;
+import pl.betoncraft.betonquest.events.CompassEvent;
+import pl.betoncraft.betonquest.events.ConversationEvent;
+import pl.betoncraft.betonquest.events.DamageEvent;
+import pl.betoncraft.betonquest.events.DelEffectEvent;
+import pl.betoncraft.betonquest.events.DoorEvent;
+import pl.betoncraft.betonquest.events.EXPEvent;
+import pl.betoncraft.betonquest.events.EffectEvent;
+import pl.betoncraft.betonquest.events.ExplosionEvent;
+import pl.betoncraft.betonquest.events.FolderEvent;
+import pl.betoncraft.betonquest.events.GiveEvent;
+import pl.betoncraft.betonquest.events.GiveJournalEvent;
+import pl.betoncraft.betonquest.events.GlobalPointEvent;
+import pl.betoncraft.betonquest.events.GlobalTagEvent;
+import pl.betoncraft.betonquest.events.IfElseEvent;
+import pl.betoncraft.betonquest.events.JournalEvent;
+import pl.betoncraft.betonquest.events.KillEvent;
+import pl.betoncraft.betonquest.events.KillMobEvent;
+import pl.betoncraft.betonquest.events.LanguageEvent;
+import pl.betoncraft.betonquest.events.LeverEvent;
+import pl.betoncraft.betonquest.events.LightningEvent;
+import pl.betoncraft.betonquest.events.MessageEvent;
+import pl.betoncraft.betonquest.events.ObjectiveEvent;
+import pl.betoncraft.betonquest.events.OpSudoEvent;
+import pl.betoncraft.betonquest.events.PartyEvent;
+import pl.betoncraft.betonquest.events.PickRandomEvent;
+import pl.betoncraft.betonquest.events.PlaysoundEvent;
+import pl.betoncraft.betonquest.events.PointEvent;
+import pl.betoncraft.betonquest.events.RunEvent;
+import pl.betoncraft.betonquest.events.ScoreboardEvent;
+import pl.betoncraft.betonquest.events.SetBlockEvent;
+import pl.betoncraft.betonquest.events.SpawnMobEvent;
+import pl.betoncraft.betonquest.events.SudoEvent;
+import pl.betoncraft.betonquest.events.TagEvent;
+import pl.betoncraft.betonquest.events.TakeEvent;
+import pl.betoncraft.betonquest.events.TeleportEvent;
+import pl.betoncraft.betonquest.events.TimeEvent;
+import pl.betoncraft.betonquest.events.TitleEvent;
+import pl.betoncraft.betonquest.events.VariableEvent;
+import pl.betoncraft.betonquest.events.WeatherEvent;
 import pl.betoncraft.betonquest.item.QuestItemHandler;
-import pl.betoncraft.betonquest.objectives.*;
+import pl.betoncraft.betonquest.objectives.ActionObjective;
+import pl.betoncraft.betonquest.objectives.ArrowShootObjective;
+import pl.betoncraft.betonquest.objectives.BlockObjective;
+import pl.betoncraft.betonquest.objectives.BreedObjective;
+import pl.betoncraft.betonquest.objectives.ChestPutObjective;
+import pl.betoncraft.betonquest.objectives.ConsumeObjective;
+import pl.betoncraft.betonquest.objectives.CraftingObjective;
+import pl.betoncraft.betonquest.objectives.DelayObjective;
+import pl.betoncraft.betonquest.objectives.DieObjective;
+import pl.betoncraft.betonquest.objectives.EnchantObjective;
+import pl.betoncraft.betonquest.objectives.EntityInteractObjective;
+import pl.betoncraft.betonquest.objectives.ExperienceObjective;
+import pl.betoncraft.betonquest.objectives.FishObjective;
+import pl.betoncraft.betonquest.objectives.KillPlayerObjective;
+import pl.betoncraft.betonquest.objectives.LocationObjective;
+import pl.betoncraft.betonquest.objectives.LogoutObjective;
+import pl.betoncraft.betonquest.objectives.MobKillObjective;
+import pl.betoncraft.betonquest.objectives.PasswordObjective;
+import pl.betoncraft.betonquest.objectives.PotionObjective;
+import pl.betoncraft.betonquest.objectives.RespawnObjective;
+import pl.betoncraft.betonquest.objectives.ShearObjective;
+import pl.betoncraft.betonquest.objectives.SmeltingObjective;
+import pl.betoncraft.betonquest.objectives.StepObjective;
+import pl.betoncraft.betonquest.objectives.TameObjective;
+import pl.betoncraft.betonquest.objectives.VariableObjective;
+import pl.betoncraft.betonquest.objectives.VehicleObjective;
 import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 import pl.betoncraft.betonquest.utils.Updater;
 import pl.betoncraft.betonquest.utils.Utils;
-import pl.betoncraft.betonquest.variables.*;
+import pl.betoncraft.betonquest.variables.GlobalPointVariable;
+import pl.betoncraft.betonquest.variables.ItemAmountVariable;
+import pl.betoncraft.betonquest.variables.LocationVariable;
+import pl.betoncraft.betonquest.variables.MathVariable;
+import pl.betoncraft.betonquest.variables.NpcNameVariable;
+import pl.betoncraft.betonquest.variables.ObjectivePropertyVariable;
+import pl.betoncraft.betonquest.variables.PlayerNameVariable;
+import pl.betoncraft.betonquest.variables.PointVariable;
+import pl.betoncraft.betonquest.variables.VersionVariable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
@@ -53,7 +195,7 @@ import java.util.regex.Pattern;
 
 /**
  * Represents BetonQuest plugin
- * 
+ *
  * @author Jakub Sapalski
  */
 public final class BetonQuest extends JavaPlugin {
@@ -82,9 +224,9 @@ public final class BetonQuest extends JavaPlugin {
 	private static HashMap<ObjectiveID, Objective> objectives = new HashMap<>();
 	private static HashMap<String, ConversationData> conversations = new HashMap<>();
 	private static HashMap<VariableID, Variable> variables = new HashMap<>();
-	
+
 	public BetonQuest() {
-	    instance = this;
+		instance = this;
 	}
 
 	@Override
@@ -158,7 +300,7 @@ public final class BetonQuest extends JavaPlugin {
 
 		// start mob kill listener
 		new MobKillListener();
-		
+
 		// start custom drop listener
 		new CustomDropListener();
 
@@ -277,7 +419,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerObjectives("logout", LogoutObjective.class);
 		registerObjectives("password", PasswordObjective.class);
 		registerObjectives("fish", FishObjective.class);
-		registerObjectives("enchant", EnchantObjective.class);		
+		registerObjectives("enchant", EnchantObjective.class);
 		registerObjectives("shear", ShearObjective.class);
 		registerObjectives("chestput", ChestPutObjective.class);
 		registerObjectives("potion", PotionObjective.class);
@@ -307,8 +449,8 @@ public final class BetonQuest extends JavaPlugin {
 		registerVariable("location", LocationVariable.class);
 		registerVariable("math", MathVariable.class);
 
-        // initialize compatibility with other plugins
-        new Compatibility();
+		// initialize compatibility with other plugins
+		new Compatibility();
 
 		// schedule quest data loading on the first tick, so all other
 		// plugins can register their types
@@ -522,7 +664,7 @@ public final class BetonQuest extends JavaPlugin {
 		}
 		// load global locations
 		new GlobalLocations();
-        // done
+		// done
 		Debug.broadcast("There are " + conditions.size() + " conditions, " + events.size() + " events, "
 				+ objectives.size() + " objectives and " + conversations.size() + " conversations loaded from "
 				+ Config.getPackages().size() + " packages.");
@@ -594,7 +736,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the plugin's instance
-	 * 
+	 *
 	 * @return the plugin's instance
 	 */
 	public static BetonQuest getInstance() {
@@ -603,7 +745,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the database instance
-	 * 
+	 *
 	 * @return Database instance
 	 */
 	public Database getDB() {
@@ -616,7 +758,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Checks if MySQL is used or not
-	 * 
+	 *
 	 * @return if MySQL is used (false means that SQLite is being used)
 	 */
 	public boolean isMySQLUsed() {
@@ -626,7 +768,7 @@ public final class BetonQuest extends JavaPlugin {
 	/**
 	 * Stores the PlayerData in a map, so it can be retrieved using
 	 * getPlayerData(String playerID)
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param playerData
@@ -641,7 +783,7 @@ public final class BetonQuest extends JavaPlugin {
 	 * Retrieves PlayerData object for specified player. If the playerData
 	 * does not exist but the player is online, it will create new playerData on
 	 * the main thread and put it into the map.
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @return PlayerData object for the player
@@ -666,7 +808,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Removes the database playerData from the map
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player whose playerData is to be removed
 	 */
@@ -689,7 +831,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new event classes by their names
-	 * 
+	 *
 	 * @param name
 	 *            name of the event type
 	 * @param eventClass
@@ -702,7 +844,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new objective classes by their names
-	 * 
+	 *
 	 * @param name
 	 *            name of the objective type
 	 * @param objectiveClass
@@ -715,7 +857,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new conversation input/output class.
-	 * 
+	 *
 	 * @param name
 	 *            name of the IO type
 	 * @param convIOClass
@@ -728,7 +870,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new variable type.
-	 * 
+	 *
 	 * @param name
 	 *            name of the variable type
 	 * @param variable
@@ -741,7 +883,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Checks if the condition described by conditionID is met
-	 * 
+	 *
 	 * @param conditionID
 	 *            ID of the condition to check, as defined in conditions.yml
 	 * @param playerID
@@ -792,7 +934,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Fires the event described by eventID
-	 * 
+	 *
 	 * @param eventID
 	 *            ID of the event to fire, as defined in events.yml
 	 * @param playerID
@@ -831,7 +973,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Creates new objective for given player
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param objectiveID
@@ -860,7 +1002,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Resumes the existing objective for given player
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param objectiveID
@@ -896,7 +1038,7 @@ public final class BetonQuest extends JavaPlugin {
 	/**
 	 * Generates new instance of a Variable. If a similar one was already
 	 * created, it will return it instead of creating a new one.
-	 * 
+	 *
 	 * @param pack
 	 *            package in which the variable is defined
 	 * @param instruction
@@ -951,7 +1093,7 @@ public final class BetonQuest extends JavaPlugin {
 	 * instruction strings, including % characters. Variables are unique, so if
 	 * the user uses the same variables multiple times, the list will contain
 	 * only one occurence of this variable.
-	 * 
+	 *
 	 * @param text
 	 *            text from which the variables will be resolved
 	 * @return the list of unique variable instructions
@@ -968,7 +1110,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the list of objectives of this player
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @return list of this player's active objectives
@@ -1009,7 +1151,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the instance of Saver
-	 * 
+	 *
 	 * @return the Saver
 	 */
 	public Saver getSaver() {
@@ -1028,7 +1170,7 @@ public final class BetonQuest extends JavaPlugin {
 	/**
 	 * Resoles the variable for specified player. If the variable is not loaded
 	 * yet it will load it on the main thread.
-	 * 
+	 *
 	 * @param packName
 	 *            name of the package
 	 * @param name
@@ -1066,7 +1208,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Renames the objective instance.
-	 * 
+	 *
 	 * @param name
 	 *            the current name
 	 * @param rename

--- a/src/main/java/pl/betoncraft/betonquest/conditions/MooncycleCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/MooncycleCondition.java
@@ -1,0 +1,43 @@
+package pl.betoncraft.betonquest.conditions;
+
+import org.bukkit.entity.Player;
+import pl.betoncraft.betonquest.Instruction;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.api.Condition;
+import pl.betoncraft.betonquest.utils.PlayerConverter;
+
+    /**
+     * This condition checks the players moon cycle (1 is full moon, 8 is Waxing Gibbous) and returns if the player is
+     * under that moon.
+     *
+     * @author Caleb Britannia (James Thacker)
+     */
+    public class MooncycleCondition extends Condition {
+
+        private int thisCycle;
+
+        public MooncycleCondition(Instruction instruction) throws InstructionParseException {
+            super(instruction);
+            try {
+
+                this.thisCycle = instruction.getInt();
+
+            } catch (Exception e) {
+
+                throw new InstructionParseException("Unable to parse moon cycle");
+            }
+        }
+
+        @Override
+        public boolean check(String playerID){
+            Player player = PlayerConverter.getPlayer(playerID);
+            int days = (int) player.getWorld().getFullTime() / 24000;
+            int phaseInt = days % 8;
+            phaseInt += 1;
+            return (phaseInt == thisCycle);
+        }
+
+    }
+
+
+

--- a/src/main/java/pl/betoncraft/betonquest/conditions/MooncycleCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/MooncycleCondition.java
@@ -3,6 +3,8 @@ package pl.betoncraft.betonquest.conditions;
 import org.bukkit.entity.Player;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.QuestRuntimeException;
+import pl.betoncraft.betonquest.VariableNumber;
 import pl.betoncraft.betonquest.api.Condition;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
@@ -14,27 +16,21 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
      */
     public class MooncycleCondition extends Condition {
 
-        private int thisCycle;
+        private VariableNumber thisCycle;
 
         public MooncycleCondition(Instruction instruction) throws InstructionParseException {
             super(instruction);
-            try {
-
-                this.thisCycle = instruction.getInt();
-
-            } catch (Exception e) {
-
-                throw new InstructionParseException("Unable to parse moon cycle");
-            }
+            this.thisCycle = instruction.getVarNum();
         }
 
+
         @Override
-        public boolean check(String playerID){
+        public boolean check(String playerID) throws QuestRuntimeException {
             Player player = PlayerConverter.getPlayer(playerID);
             int days = (int) player.getWorld().getFullTime() / 24000;
             int phaseInt = days % 8;
             phaseInt += 1;
-            return (phaseInt == thisCycle);
+            return (phaseInt == thisCycle.getInt(playerID));
         }
 
     }


### PR DESCRIPTION
Added a new condition which checks the moon cycle (of the world the player is currently in). For a frame of reference, 1 is Full moon; a list of full moon cycles can be found here: https://minecraft.gamepedia.com/Moon.


Also it seems a massive amount of imports was changed within the Betonquest.java file. The plugin works fine but feel free to revoke these changes