### PR TITLE
Fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /doc/
 /dependency-reduced-pom.xml
 .vscode/
+.factorypath

--- a/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -1,17 +1,17 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -185,7 +185,7 @@ import pl.betoncraft.betonquest.variables.VersionVariable;
 
 /**
  * Represents BetonQuest plugin
- * 
+ *
  * @author Jakub Sapalski
  */
 public final class BetonQuest extends JavaPlugin {
@@ -214,7 +214,7 @@ public final class BetonQuest extends JavaPlugin {
 	private static HashMap<ObjectiveID, Objective> objectives = new HashMap<>();
 	private static HashMap<String, ConversationData> conversations = new HashMap<>();
 	private static HashMap<VariableID, Variable> variables = new HashMap<>();
-	
+
 	public BetonQuest() {
 	    instance = this;
 	}
@@ -290,7 +290,7 @@ public final class BetonQuest extends JavaPlugin {
 
 		// start mob kill listener
 		new MobKillListener();
-		
+
 		// start custom drop listener
 		new CustomDropListener();
 
@@ -408,7 +408,7 @@ public final class BetonQuest extends JavaPlugin {
 		registerObjectives("logout", LogoutObjective.class);
 		registerObjectives("password", PasswordObjective.class);
 		registerObjectives("fish", FishObjective.class);
-		registerObjectives("enchant", EnchantObjective.class);		
+		registerObjectives("enchant", EnchantObjective.class);
 		registerObjectives("shear", ShearObjective.class);
 		registerObjectives("chestput", ChestPutObjective.class);
 		registerObjectives("potion", PotionObjective.class);
@@ -700,6 +700,7 @@ public final class BetonQuest extends JavaPlugin {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void onDisable() {
 		// suspend all conversations
 		for (Player player : Bukkit.getOnlinePlayers()) {
@@ -725,7 +726,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the plugin's instance
-	 * 
+	 *
 	 * @return the plugin's instance
 	 */
 	public static BetonQuest getInstance() {
@@ -734,7 +735,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the database instance
-	 * 
+	 *
 	 * @return Database instance
 	 */
 	public Database getDB() {
@@ -747,7 +748,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Checks if MySQL is used or not
-	 * 
+	 *
 	 * @return if MySQL is used (false means that SQLite is being used)
 	 */
 	public boolean isMySQLUsed() {
@@ -757,7 +758,7 @@ public final class BetonQuest extends JavaPlugin {
 	/**
 	 * Stores the PlayerData in a map, so it can be retrieved using
 	 * getPlayerData(String playerID)
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param playerData
@@ -772,7 +773,7 @@ public final class BetonQuest extends JavaPlugin {
 	 * Retrieves PlayerData object for specified player. If the playerData
 	 * does not exist but the player is online, it will create new playerData on
 	 * the main thread and put it into the map.
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @return PlayerData object for the player
@@ -797,7 +798,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Removes the database playerData from the map
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player whose playerData is to be removed
 	 */
@@ -807,7 +808,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new condition classes by their names
-	 * 
+	 *
 	 * @param name
 	 *            name of the condition type
 	 * @param conditionClass
@@ -820,7 +821,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new event classes by their names
-	 * 
+	 *
 	 * @param name
 	 *            name of the event type
 	 * @param eventClass
@@ -833,7 +834,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new objective classes by their names
-	 * 
+	 *
 	 * @param name
 	 *            name of the objective type
 	 * @param objectiveClass
@@ -846,7 +847,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new conversation input/output class.
-	 * 
+	 *
 	 * @param name
 	 *            name of the IO type
 	 * @param convIOClass
@@ -859,7 +860,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Registers new variable type.
-	 * 
+	 *
 	 * @param name
 	 *            name of the variable type
 	 * @param variable
@@ -872,7 +873,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Checks if the condition described by conditionID is met
-	 * 
+	 *
 	 * @param conditionID
 	 *            ID of the condition to check, as defined in conditions.yml
 	 * @param playerID
@@ -923,7 +924,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Fires the event described by eventID
-	 * 
+	 *
 	 * @param eventID
 	 *            ID of the event to fire, as defined in events.yml
 	 * @param playerID
@@ -962,7 +963,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Creates new objective for given player
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param objectiveID
@@ -991,7 +992,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Resumes the existing objective for given player
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @param objectiveID
@@ -1027,7 +1028,7 @@ public final class BetonQuest extends JavaPlugin {
 	/**
 	 * Generates new instance of a Variable. If a similar one was already
 	 * created, it will return it instead of creating a new one.
-	 * 
+	 *
 	 * @param pack
 	 *            package in which the variable is defined
 	 * @param instruction
@@ -1082,7 +1083,7 @@ public final class BetonQuest extends JavaPlugin {
 	 * instruction strings, including % characters. Variables are unique, so if
 	 * the user uses the same variables multiple times, the list will contain
 	 * only one occurence of this variable.
-	 * 
+	 *
 	 * @param text
 	 *            text from which the variables will be resolved
 	 * @return the list of unique variable instructions
@@ -1099,7 +1100,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the list of objectives of this player
-	 * 
+	 *
 	 * @param playerID
 	 *            ID of the player
 	 * @return list of this player's active objectives
@@ -1140,7 +1141,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Returns the instance of Saver
-	 * 
+	 *
 	 * @return the Saver
 	 */
 	public Saver getSaver() {
@@ -1159,7 +1160,7 @@ public final class BetonQuest extends JavaPlugin {
 	/**
 	 * Resoles the variable for specified player. If the variable is not loaded
 	 * yet it will load it on the main thread.
-	 * 
+	 *
 	 * @param packName
 	 *            name of the package
 	 * @param name
@@ -1197,7 +1198,7 @@ public final class BetonQuest extends JavaPlugin {
 
 	/**
 	 * Renames the objective instance.
-	 * 
+	 *
 	 * @param name
 	 *            the current name
 	 * @param rename

--- a/src/main/java/pl/betoncraft/betonquest/ID.java
+++ b/src/main/java/pl/betoncraft/betonquest/ID.java
@@ -1,34 +1,36 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package pl.betoncraft.betonquest;
 
+import java.util.stream.Stream;
+
 import pl.betoncraft.betonquest.config.Config;
 import pl.betoncraft.betonquest.config.ConfigPackage;
 
 public abstract class ID {
-	
+
 	public static final String upStr = "_"; // string used as "up the hierarchy" package
-	
+
 	protected String id;
 	protected ConfigPackage pack;
 	protected Instruction instruction;
 	protected String rawInstruction;
-	
+
 	public ID(ConfigPackage pack, String id) throws ObjectNotFoundException {
 
 		// id must be specified
@@ -39,8 +41,16 @@ public abstract class ID {
 		// resolve package name
 		if (id.contains(".")) {
 			// id has specified a package, get it!
-			int dotIndex = id.indexOf('.');
-			String packName = id.substring(0, dotIndex);
+			String[] parts = id.split("\\.");
+
+			// ID after splitting must give two non-empty strings
+			if (parts.length != 2 || Stream.of(parts).anyMatch(part -> part.length() == 0)) {
+				throw new ObjectNotFoundException(String.format("ID %s has incorrect format", id));
+			}
+
+			String packName = parts[0];
+			String idName = parts[1];
+
 			if (pack != null && packName.startsWith(upStr + "-")) {
 				// resolve relative name if we have a supplied package
 				String[] root = pack.getName().split("-");
@@ -74,7 +84,7 @@ public abstract class ID {
 				// use package name as absolute path if no relative path is available
 				this.pack = Config.getPackages().get(packName);
 			}
-			this.id = id.substring(dotIndex + 1); // FIXME error if the id is empty, dot is last
+			this.id = idName;
 		} else {
 			// id does not specify package, use supplied package
 			if (pack != null) {
@@ -90,24 +100,24 @@ public abstract class ID {
 			throw new ObjectNotFoundException("Package in ID '" + id + "' does not exist");
 		}
 	}
-	
+
 	public ConfigPackage getPackage() {
 		return pack;
 	}
-	
+
 	public String getBaseID() {
 		return id;
 	}
-	
+
 	public String getFullID() {
 		return pack.getName() + "." + getBaseID();
 	}
-	
+
 	@Override
 	public String toString() {
 		return getFullID();
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof ID) {
@@ -117,7 +127,7 @@ public abstract class ID {
 		}
 		return false;
 	}
-	
+
 	public Instruction generateInstruction() {
 		if (rawInstruction == null) {
 			return null;

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/UnsupportedVersionException.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/UnsupportedVersionException.java
@@ -16,6 +16,8 @@ import org.bukkit.plugin.Plugin;
  */
 public class UnsupportedVersionException extends Exception {
 
+    private static final long serialVersionUID = -1235158967291211169L;
+
     private final String currentVersion;
     private final String requiredVersion;
     private final Plugin plugin;

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -58,7 +58,6 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
     private Map<NPC, List<NPCHologram>> npcs = new HashMap<>();
 
     private int interval;
-    private int tick = 0;
     private boolean enabled = false;
 
     // Updater

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/effectlib/ParticleEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/effectlib/ParticleEvent.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import de.slikey.effectlib.util.DynamicLocation;
@@ -64,7 +63,6 @@ public class ParticleEvent extends QuestEvent {
     public void run(String playerID) throws QuestRuntimeException {
         Player p = PlayerConverter.getPlayer(playerID);
         Location location = (loc == null) ? p.getLocation() : loc.getLocation(playerID);
-        Entity originEntity = (loc == null) ? p : null;
         Player targetPlayer = pr1vate ? p : null;
         EffectLibIntegrator.getEffectManager().start(effectClass,
                                                      parameters,

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/quests/QuestCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/quests/QuestCondition.java
@@ -1,23 +1,22 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package pl.betoncraft.betonquest.compatibility.quests;
 
-import me.blackvein.quests.Quests;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
 import pl.betoncraft.betonquest.api.Condition;
@@ -25,7 +24,7 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
 
 /**
  * Checks if the player has done specified quest before.
- * 
+ *
  * @author Jakub Sapalski
  */
 public class QuestCondition extends Condition {

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/quests/QuestEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/quests/QuestEvent.java
@@ -1,24 +1,23 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package pl.betoncraft.betonquest.compatibility.quests;
 
 import me.blackvein.quests.Quest;
-import me.blackvein.quests.Quests;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
 import pl.betoncraft.betonquest.utils.Debug;
@@ -26,7 +25,7 @@ import pl.betoncraft.betonquest.utils.PlayerConverter;
 
 /**
  * Starts a quests in Quests plugin.
- * 
+ *
  * @author Jakub Sapalski
  */
 public class QuestEvent extends pl.betoncraft.betonquest.api.QuestEvent {

--- a/src/main/java/pl/betoncraft/betonquest/compatibility/quests/QuestsIntegrator.java
+++ b/src/main/java/pl/betoncraft/betonquest/compatibility/quests/QuestsIntegrator.java
@@ -17,8 +17,6 @@
  */
 package pl.betoncraft.betonquest.compatibility.quests;
 
-import java.util.Collections;
-
 import org.bukkit.Bukkit;
 
 import me.blackvein.quests.Quests;

--- a/src/main/java/pl/betoncraft/betonquest/conditions/GlobalPointCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/GlobalPointCondition.java
@@ -1,17 +1,17 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,16 +20,12 @@ package pl.betoncraft.betonquest.conditions;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
-import pl.betoncraft.betonquest.Point;
 import pl.betoncraft.betonquest.QuestRuntimeException;
-import pl.betoncraft.betonquest.VariableNumber;
-import pl.betoncraft.betonquest.api.Condition;
-import pl.betoncraft.betonquest.utils.Utils;
 
 /**
  * Requires a specified amount of global points (or more) in specified
  * category
- * 
+ *
  * @author Jonas Blocher
  */
 public class GlobalPointCondition extends PointCondition {

--- a/src/main/java/pl/betoncraft/betonquest/conditions/GlobalTagCondition.java
+++ b/src/main/java/pl/betoncraft/betonquest/conditions/GlobalTagCondition.java
@@ -1,17 +1,17 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,12 +20,10 @@ package pl.betoncraft.betonquest.conditions;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
-import pl.betoncraft.betonquest.api.Condition;
-import pl.betoncraft.betonquest.utils.Utils;
 
 /**
  * Requires the specified global tag to be set
- * 
+ *
  * @author Jonas Blocher
  */
 public class GlobalTagCondition extends TagCondition {

--- a/src/main/java/pl/betoncraft/betonquest/events/DelEffectEvent.java
+++ b/src/main/java/pl/betoncraft/betonquest/events/DelEffectEvent.java
@@ -17,7 +17,6 @@
  */
 package pl.betoncraft.betonquest.events;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
+++ b/src/main/java/pl/betoncraft/betonquest/utils/LocalChatPaginator.java
@@ -21,8 +21,6 @@ package pl.betoncraft.betonquest.utils;
 import org.bukkit.ChatColor;
 import org.bukkit.util.ChatPaginator;
 
-import java.awt.font.FontRenderContext;
-import java.awt.geom.AffineTransform;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -85,9 +83,6 @@ public class LocalChatPaginator extends ChatPaginator {
      * @return An array of word-wrapped lines.
      */
     public static String[] wordWrap(String rawString, int lineLength) {
-        FontRenderContext frc = new FontRenderContext(new AffineTransform(), true, true);
-
-
         // A null string is a single line
         if (rawString == null) {
             return new String[]{""};

--- a/src/main/java/pl/betoncraft/betonquest/variables/GlobalPointVariable.java
+++ b/src/main/java/pl/betoncraft/betonquest/variables/GlobalPointVariable.java
@@ -1,17 +1,17 @@
 /**
  * BetonQuest - advanced quests for Bukkit
  * Copyright (C) 2016  Jakub "Co0sh" Sapalski
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,12 +20,11 @@ package pl.betoncraft.betonquest.variables;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.Instruction;
 import pl.betoncraft.betonquest.InstructionParseException;
-import pl.betoncraft.betonquest.Point;
 
 /**
  * Allows you to display total amount of global points or amount of global points remaining to
  * some other amount.
- * 
+ *
  * @author Jonas Blocher
  */
 public class GlobalPointVariable extends PointVariable {


### PR DESCRIPTION
In `MathVariable.java` there's an `Operation` enum. It has some static methods which are not used. Can we get rid of that?

Please don't merge before we resolve this problem. There's also the issue of missing Javadocs which I have not fixed here yet.