### PR TITLE
All Journal Config + Fix Date Issue

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/Journal.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/Journal.java
@@ -191,7 +191,7 @@ public class Journal {
                 if (dateParts.length > 1) {
                     hour = "§" + Config.getString("config.journal_colors.date.hour") + dateParts[1];
                 }
-                datePrefix = day + " " + hour;
+                datePrefix = day + " " + hour + "\n";
             }
             // get package and name of the pointer
             String[] parts = pointer.getPointer().split("\\.");
@@ -230,8 +230,7 @@ public class Journal {
             }
 
             // add the entry to the list
-            texts.add(datePrefix + "§" + Config.getString("config.journal_colors.text") + "\n"
-                    + text);
+            texts.add(datePrefix + "§" + Config.getString("config.journal_colors.text") + text);
         }
     }
 
@@ -316,8 +315,7 @@ public class Journal {
         for (int i : sorted) {
             sortedLines.add(lines.get(i));
         }
-        String finalLine = StringUtils.join(sortedLines, '\n').replace('&', '§');
-        return finalLine;
+        return StringUtils.join(sortedLines, '\n').replace('&', '§');
     }
 
     /**
@@ -371,22 +369,33 @@ public class Journal {
         BookMeta meta = (BookMeta) item.getItemMeta();
         meta.setTitle(Utils.format(Config.getMessage(lang, "journal_title")));
         meta.setAuthor(PlayerConverter.getPlayer(playerID).getName());
-        List<String> lore = new ArrayList<String>();
+        List<String> lore = new ArrayList<>();
         lore.add(Utils.format(Config.getMessage(lang, "journal_lore")));
         meta.setLore(lore);
         // add main page and generate pages from texts
         List<String> finalList = new ArrayList<>();
         if (Config.getString("config.journal.one_entry_per_page").equalsIgnoreCase("false")) {
             String color = Config.getString("config.journal_colors.line");
+            String separator = Config.parseMessage(playerID, "journal_separator", null);
+            if (separator == null) {
+                separator = "---------------";
+            }
+            String line = "\n§" + color + separator + "\n";
+
+            if (Config.getString("config.journal.show_separator") != null &&
+                    Config.getString("config.journal.show_separator").equalsIgnoreCase("false")) {
+                line = "\n";
+            }
+
             StringBuilder stringBuilder = new StringBuilder();
             for (String entry : getText()) {
-                stringBuilder.append(entry + "\n§" + color + "---------------\n");
+                stringBuilder.append(entry).append(line);
             }
             if (mainPage != null && mainPage.length() > 0) {
                 if (Config.getString("config.journal.full_main_page").equalsIgnoreCase("true")) {
                     finalList.addAll(Utils.pagesFromString(mainPage));
                 } else {
-                    stringBuilder.insert(0, mainPage + "\n§" + color + "---------------\n");
+                    stringBuilder.insert(0, mainPage + line);
                 }
             }
             String wholeString = stringBuilder.toString().trim();

--- a/BetonQuest-core/src/main/resources/changelog.txt
+++ b/BetonQuest-core/src/main/resources/changelog.txt
@@ -12,6 +12,9 @@ Changes:
 Fixes:
   * Resolve variables in journal pages.
   * WATER and LAVA can be specified in Action Objective
+  * Journals without dates now don't leave blank lines
+  * Journal separator can be disabled or customized
+
 
 v1.10-dev
   - Development versions can be full of bugs. If you find any, please report them on GitHub Issues.

--- a/docs/02-Installation-and-Configuration.md
+++ b/docs/02-Installation-and-Configuration.md
@@ -48,6 +48,7 @@ The configuration of BetonQuest is done mainly in _config.yml_ file. All options
     - `reversed_order` controls the chronological order of entries in the journal. By default the entries are ordered from newest to oldest. You can reverse it, but it will force players to click through a lot of pages to get to the latest entry.
     - `hide_date` hides the date of each entry. Set it to true if you don't want this functionality.
     - `full_main_page` makes the main page take always a full page. If you display a lot of information you should probably make this true. If you use main page only for small notifications, set it to false, so the entries can follow immediately.
+    - `show_separator` shows a separator between journal entries (default: true). Customize the separator in `messages.yml` with the key `journal_separator`.
 * `journal_colors` controls the colors used in the journal. It takes color codes without the `&` character.
     - `date.day` is a day number
     - `date.hour` is a hour number


### PR DESCRIPTION
# Notes:
  * If date is hidden, then the journal won't leave blank lines
  * Separator can be hidden by setting 'journal.show_separator' to false. Defaults to true
  * Separator can be customized by adding 'journal_separator' to messages.yml. Defaults to "---------------"

# Changes:
  * Updated journal to include date fix
  * Updated journal to allow hiding separator and customizing through messages.
  * Updated Documentation.

# Closes:
  * Closes #818

# References:
  * See: https://github.com/Co0sh/BetonQuest/pull/857