### PR TITLE
Add Configuration for chest convIO

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -1,19 +1,19 @@
 /*
- * BetonQuest - advanced quests for Bukkit
- * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *  BetonQuest - advanced quests for Bukkit
+ *  Copyright (C) 2016  Jakub "Co0sh" Sapalski
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package pl.betoncraft.betonquest.conversation;
 
@@ -213,27 +213,21 @@ public class InventoryConvIO implements Listener, ConversationIO {
                 string.append(color);
             }
 
-            // If both showNumber and showNPCText is false, we can put the response directly into the display name
-            if (!showNumber && !showNPCText) {
-                meta.setDisplayName(Utils.replaceReset(string.toString() + "- " + optionColor + option, optionColor));
-                meta.setDisplayName(Utils.replaceReset(string.toString() + "- " + optionColor + option, optionColor));
+            if (showNumber) {
+                meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
             } else {
-                if (showNumber) {
-                    meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
-                } else {
-                    meta.setDisplayName(" ");
-                }
-
-                ArrayList<String> lines = new ArrayList<>();
-
-                if (showNPCText) {
-                    lines.addAll(stringToLines(response, npcTextColor,
-                            npcNameColor + npcName + ChatColor.RESET + ": "));
-                }
-
-                lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
-                meta.setLore(lines);
+                meta.setDisplayName(" ");
             }
+
+            ArrayList<String> lines = new ArrayList<>();
+
+            if (showNPCText) {
+                lines.addAll(stringToLines(response, npcTextColor,
+                        npcNameColor + npcName + ChatColor.RESET + ": "));
+            }
+
+            lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
+            meta.setLore(lines);
 
             item.setItemMeta(meta);
             buttons[j] = item;

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -1,19 +1,19 @@
 /*
- *  BetonQuest - advanced quests for Bukkit
- *  Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package pl.betoncraft.betonquest.conversation;
 
@@ -35,10 +35,12 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.utils.LocalChatPaginator;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 import pl.betoncraft.betonquest.utils.Utils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 
 /**
@@ -157,7 +159,11 @@ public class InventoryConvIO implements Listener, ConversationIO {
         SkullMeta npcMeta = (SkullMeta) npc.getItemMeta();
         npcMeta.setOwner(npcName);
         npcMeta.setDisplayName(npcNameColor + npcName);
-        npcMeta.setLore(stringToLines(response, npcTextColor, null));
+        // NPC Text
+        npcMeta.setLore(Arrays.asList(LocalChatPaginator.wordWrap(
+                Utils.replaceReset(response, npcTextColor),
+                45)));
+
         npc.setItemMeta(npcMeta);
         buttons[0] = npc;
         // this is the number of an option
@@ -222,11 +228,17 @@ public class InventoryConvIO implements Listener, ConversationIO {
             ArrayList<String> lines = new ArrayList<>();
 
             if (showNPCText) {
-                lines.addAll(stringToLines(response, npcTextColor,
-                        npcNameColor + npcName + ChatColor.RESET + ": "));
+                // NPC Text
+                lines.addAll(Arrays.asList(LocalChatPaginator.wordWrap(
+                        Utils.replaceReset(npcNameColor + npcName + ChatColor.RESET + ": " +
+                                response, npcTextColor),
+                        45)));
             }
 
-            lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
+            // Option Text
+            lines.addAll(Arrays.asList(LocalChatPaginator.wordWrap(
+                    Utils.replaceReset(string.toString() + "- " + option, optionColor),
+                    45)));
             meta.setLore(lines);
 
             item.setItemMeta(meta);

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -22,6 +22,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -65,6 +66,10 @@ public class InventoryConvIO implements Listener, ConversationIO {
     protected Location loc;
     protected boolean printMessages = false;
 
+    // Config
+    protected boolean showNumber = true;
+    protected boolean showNPCText = true;
+
     public InventoryConvIO(Conversation conv, String playerID) {
         this.conv = conv;
         this.player = PlayerConverter.getPlayer(playerID);
@@ -100,6 +105,14 @@ public class InventoryConvIO implements Listener, ConversationIO {
         }
         answerPrefix = string.toString();
         loc = player.getLocation();
+
+        // Load config
+        if (BetonQuest.getInstance().getConfig().contains("conversation_IO_config.chest")) {
+            ConfigurationSection config = BetonQuest.getInstance().getConfig().getConfigurationSection("conversation_IO_config.chest");
+            showNumber = config.getBoolean("show_number", true);
+            showNPCText = config.getBoolean("show_npc_text", true);
+        }
+
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance().getJavaPlugin());
     }
 
@@ -194,15 +207,34 @@ public class InventoryConvIO implements Listener, ConversationIO {
             ItemStack item = new ItemStack(material);
             item.setDurability(data);
             ItemMeta meta = item.getItemMeta();
-            meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
-            ArrayList<String> lines = stringToLines(response, npcTextColor,
-                    npcNameColor + npcName + ChatColor.RESET + ": ");
+
             StringBuilder string = new StringBuilder();
             for (ChatColor color : ConversationColors.getColors().get("number")) {
                 string.append(color);
             }
-            lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
-            meta.setLore(lines);
+
+            // If both showNumber and showNPCText is false, we can put the response directly into the display name
+            if (!showNumber && !showNPCText) {
+                meta.setDisplayName(Utils.replaceReset(string.toString() + "- " + optionColor + option, optionColor));
+                meta.setDisplayName(Utils.replaceReset(string.toString() + "- " + optionColor + option, optionColor));
+            } else {
+                if (showNumber) {
+                    meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
+                } else {
+                    meta.setDisplayName(" ");
+                }
+
+                ArrayList<String> lines = new ArrayList<>();
+
+                if (showNPCText) {
+                    lines.addAll(stringToLines(response, npcTextColor,
+                            npcNameColor + npcName + ChatColor.RESET + ": "));
+                }
+
+                lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
+                meta.setLore(lines);
+            }
+
             item.setItemMeta(meta);
             buttons[j] = item;
         }

--- a/BetonQuest-core/src/main/resources/changelog.txt
+++ b/BetonQuest-core/src/main/resources/changelog.txt
@@ -3,6 +3,7 @@ Additions:
   * Support Minecraft 1.8 - 1.13.2+
   * New Block Selector to select blocks by material and attributes. Can use wildcards as well.
   * New 'mooncycle' condition - Determine what phase the moon is in
+  * Chest ConversationIO can now be configured to show NPC text per option.
 
 v1.10-dev
   - Development versions can be full of bugs. If you find any, please report them on GitHub Issues.

--- a/BetonQuest-v1.12-R1/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/BetonQuest-v1.12-R1/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -1,19 +1,19 @@
 /*
- * BetonQuest - advanced quests for Bukkit
- * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *  BetonQuest - advanced quests for Bukkit
+ *  Copyright (C) 2016  Jakub "Co0sh" Sapalski
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package pl.betoncraft.betonquest.conversation;
 
@@ -210,26 +210,21 @@ public class InventoryConvIO implements Listener, ConversationIO {
                 string.append(color);
             }
 
-            // If both showNumber and showNPCText is false, we can put the response directly into the display name
-            if (!showNumber && !showNPCText) {
-                meta.setDisplayName(Utils.replaceReset(string.toString() + "- " + optionColor + option, optionColor));
+            if (showNumber) {
+                meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
             } else {
-                if (showNumber) {
-                    meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
-                } else {
-                    meta.setDisplayName(" ");
-                }
-
-                ArrayList<String> lines = new ArrayList<>();
-
-                if (showNPCText) {
-                    lines.addAll(stringToLines(response, npcTextColor,
-                            npcNameColor + npcName + ChatColor.RESET + ": "));
-                }
-
-                lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
-                meta.setLore(lines);
+                meta.setDisplayName(" ");
             }
+
+            ArrayList<String> lines = new ArrayList<>();
+
+            if (showNPCText) {
+                lines.addAll(stringToLines(response, npcTextColor,
+                        npcNameColor + npcName + ChatColor.RESET + ": "));
+            }
+
+            lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
+            meta.setLore(lines);
 
             item.setItemMeta(meta);
             buttons[j] = item;

--- a/BetonQuest-v1.12-R1/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/BetonQuest-v1.12-R1/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -22,6 +22,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -65,6 +66,10 @@ public class InventoryConvIO implements Listener, ConversationIO {
     protected Location loc;
     protected boolean printMessages = false;
 
+    // Config
+    protected boolean showNumber = true;
+    protected boolean showNPCText = true;
+
     public InventoryConvIO(Conversation conv, String playerID) {
         this.conv = conv;
         this.player = PlayerConverter.getPlayer(playerID);
@@ -100,6 +105,14 @@ public class InventoryConvIO implements Listener, ConversationIO {
         }
         answerPrefix = string.toString();
         loc = player.getLocation();
+
+        // Load config
+        if (BetonQuest.getInstance().getConfig().contains("conversation_IO_config.chest")) {
+            ConfigurationSection config = BetonQuest.getInstance().getConfig().getConfigurationSection("conversation_IO_config.chest");
+            showNumber = config.getBoolean("show_number", true);
+            showNPCText = config.getBoolean("show_npc_text", true);
+        }
+
         Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance().getJavaPlugin());
     }
 
@@ -191,15 +204,33 @@ public class InventoryConvIO implements Listener, ConversationIO {
             ItemStack item = new ItemStack(material);
             item.setDurability(data);
             ItemMeta meta = item.getItemMeta();
-            meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
-            ArrayList<String> lines = stringToLines(response, npcTextColor,
-                    npcNameColor + npcName + ChatColor.RESET + ": ");
+
             StringBuilder string = new StringBuilder();
             for (ChatColor color : ConversationColors.getColors().get("number")) {
                 string.append(color);
             }
-            lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
-            meta.setLore(lines);
+
+            // If both showNumber and showNPCText is false, we can put the response directly into the display name
+            if (!showNumber && !showNPCText) {
+                meta.setDisplayName(Utils.replaceReset(string.toString() + "- " + optionColor + option, optionColor));
+            } else {
+                if (showNumber) {
+                    meta.setDisplayName(numberFormat.replace("%number%", Integer.toString(next)));
+                } else {
+                    meta.setDisplayName(" ");
+                }
+
+                ArrayList<String> lines = new ArrayList<>();
+
+                if (showNPCText) {
+                    lines.addAll(stringToLines(response, npcTextColor,
+                            npcNameColor + npcName + ChatColor.RESET + ": "));
+                }
+
+                lines.addAll(stringToLines(option, optionColor, string.toString() + "- "));
+                meta.setLore(lines);
+            }
+
             item.setItemMeta(meta);
             buttons[j] = item;
         }

--- a/docs/02-Installation-and-Configuration.md
+++ b/docs/02-Installation-and-Configuration.md
@@ -62,6 +62,10 @@ The configuration of BetonQuest is done mainly in _config.yml_ file. All options
     - `option` is the text of an option
 * `date_format` is the Java [date format](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in journal dates. It needs to have a space between the day and hour.
 * `debug` is responsible for logging plugin's activity to _debug.log_ file in _logs_ directory. You shouldn't turn this on as it can slow your server down. However if you experience any errors turn this on, let the plugin gather the data and send logs to the developer. Note that first run of the plugin will be logged anyway, just as a precaution.
+* `conversation_IO_config` manages settings for individual conoversation IO's:
+    - `chest` manages settings for the chest conversation IO
+        - `show_number` will show the player number option if true (default: true)
+        - `show_npc_text` will show the npc text in every player option if true (default: true)
 
 ## Updating
 


### PR DESCRIPTION
# Notes:
  * Add the following lines to config.yml to control chest convIO settings. The defaults are shown

```
conversation_IO_config:
  chest:
    show_number: true
    show_npc_text: true
```

  * If both show_number and show_npc_text are false then the player option will be shown in the title of the item.

# Changes:
  * Add 2 new options to config.yml that specify if the chest conversationIO will show the player option number, and if the npc text is shown in each option.
  * Update Documentation

# References:
  * See: https://github.com/Co0sh/BetonQuest/pull/856