### PR TITLE
Conversation Condition

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -44,6 +44,7 @@ import pl.betoncraft.betonquest.conditions.BiomeCondition;
 import pl.betoncraft.betonquest.conditions.CheckCondition;
 import pl.betoncraft.betonquest.conditions.ChestItemCondition;
 import pl.betoncraft.betonquest.conditions.ConjunctionCondition;
+import pl.betoncraft.betonquest.conditions.ConversationCondition;
 import pl.betoncraft.betonquest.conditions.DayOfWeekCondition;
 import pl.betoncraft.betonquest.conditions.EffectCondition;
 import pl.betoncraft.betonquest.conditions.EmptySlotsCondition;
@@ -572,6 +573,7 @@ public class BetonQuest extends VersionPlugin {
         registerConditions("realtime", RealTimeCondition.class);
         registerConditions("looking", LookingAtCondition.class);
         registerConditions("facing", FacingCondition.class);
+        registerConditions("conversation", ConversationCondition.class);
 
         // register events
         registerEvents("message", MessageEvent.class);

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conditions/ConversationCondition.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conditions/ConversationCondition.java
@@ -1,0 +1,60 @@
+/*
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.betoncraft.betonquest.conditions;
+
+import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.Instruction;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.QuestRuntimeException;
+import pl.betoncraft.betonquest.api.Condition;
+import pl.betoncraft.betonquest.conversation.ConversationData;
+import pl.betoncraft.betonquest.utils.Utils;
+
+/**
+ * Checks if the conversation with player has at least one possible option
+ * <p>
+ * Example:
+ * {@code conversation <name of conversation>}
+ **/
+public class ConversationCondition extends Condition {
+
+    private String conversationID;
+
+    public ConversationCondition(Instruction instruction) throws InstructionParseException {
+        super(instruction);
+
+        if (instruction.next() == null) {
+            throw new InstructionParseException("Missing conversation parameter");
+        }
+
+        conversationID = instruction.current();
+    }
+
+    @Override
+    public boolean check(String playerID) throws QuestRuntimeException {
+
+        ConversationData conversation = BetonQuest.getInstance().getConversation(Utils.addPackage(instruction.getPackage(), conversationID));
+
+        if (conversation == null) {
+            throw new QuestRuntimeException("Conversation does not exist: " + instruction.getPackage().getName() + conversationID);
+        }
+
+        return conversation.isReady(playerID);
+    }
+
+}

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
@@ -343,6 +343,33 @@ public class ConversationData {
         return options.get(option).getPointers();
     }
 
+    /**
+     * Check if conversation has at least one valid option for player
+     */
+    public boolean isReady(String playerID) {
+        options:
+        for (String option : getStartingOptions()) {
+            String convName, optionName;
+            if (option.contains(".")) {
+                String[] parts = option.split("\\.");
+                convName = parts[0];
+                optionName = parts[1];
+            } else {
+                convName = getName();
+                optionName = option;
+            }
+            ConfigPackage pack = Config.getPackages().get(getPackName());
+            ConversationData currentData = BetonQuest.getInstance().getConversation(pack.getName() + "." + convName);
+            for (ConditionID condition : currentData.getConditionIDs(optionName, ConversationData.OptionType.NPC)) {
+                if (!BetonQuest.condition(playerID, condition)) {
+                    continue options;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     public enum OptionType {
         NPC, PLAYER
     }

--- a/BetonQuest-core/src/main/resources/changelog.txt
+++ b/BetonQuest-core/src/main/resources/changelog.txt
@@ -3,6 +3,7 @@ Additions:
   * Support Minecraft 1.8 - 1.13.2+
   * New Block Selector to select blocks by material and attributes. Can use wildcards as well.
   * New 'mooncycle' condition - Determine what phase the moon is in
+  * New 'conversation' condition that will return true if there is at least 1 conversation option available to an NPC
 
 v1.10-dev
   - Development versions can be full of bugs. If you find any, please report them on GitHub Issues.

--- a/BetonQuest-v1.8-R3/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/BetonQuest-v1.8-R3/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -44,6 +44,7 @@ import pl.betoncraft.betonquest.conditions.BiomeCondition;
 import pl.betoncraft.betonquest.conditions.CheckCondition;
 import pl.betoncraft.betonquest.conditions.ChestItemCondition;
 import pl.betoncraft.betonquest.conditions.ConjunctionCondition;
+import pl.betoncraft.betonquest.conditions.ConversationCondition;
 import pl.betoncraft.betonquest.conditions.DayOfWeekCondition;
 import pl.betoncraft.betonquest.conditions.EffectCondition;
 import pl.betoncraft.betonquest.conditions.EmptySlotsCondition;
@@ -569,6 +570,7 @@ public class BetonQuest extends VersionPlugin {
         registerConditions("realtime", RealTimeCondition.class);
         registerConditions("looking", LookingAtCondition.class);
         registerConditions("facing", FacingCondition.class);
+        registerConditions("conversation", ConversationCondition.class);
 
         // register events
         registerEvents("message", MessageEvent.class);

--- a/BetonQuest-v1.9-R2/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/BetonQuest-v1.9-R2/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -44,6 +44,7 @@ import pl.betoncraft.betonquest.conditions.BiomeCondition;
 import pl.betoncraft.betonquest.conditions.CheckCondition;
 import pl.betoncraft.betonquest.conditions.ChestItemCondition;
 import pl.betoncraft.betonquest.conditions.ConjunctionCondition;
+import pl.betoncraft.betonquest.conditions.ConversationCondition;
 import pl.betoncraft.betonquest.conditions.DayOfWeekCondition;
 import pl.betoncraft.betonquest.conditions.EffectCondition;
 import pl.betoncraft.betonquest.conditions.EmptySlotsCondition;
@@ -571,6 +572,7 @@ public class BetonQuest extends VersionPlugin {
         registerConditions("realtime", RealTimeCondition.class);
         registerConditions("looking", LookingAtCondition.class);
         registerConditions("facing", FacingCondition.class);
+        registerConditions("conversation", ConversationCondition.class);
 
         // register events
         registerEvents("message", MessageEvent.class);

--- a/docs/06-Conditions-List.md
+++ b/docs/06-Conditions-List.md
@@ -241,3 +241,8 @@ Checks if the player is looking in the given direction. Valid directions are `UP
 Checks if the player is looking at a block with the given location or material. You must specify either `loc:` optional (the location of the block) or `type:` optional as a `block selector`. You can also specify both.
 
 **Example:** `looking loc:12.0;14.0;-15.0;world type:STONE`
+## Conversation: `conversation`
+
+This condition will check if a conversation has an available starting option. If no starting option has a condition that returns true then this will return false.
+
+**Example**: `conversation innkeeper`


### PR DESCRIPTION
Implement Conversation Condition

Changes:
  * Add method to ConversationData 'isReady' that will return true if a starting option is available
  * Add condition 'conversation <conversationID>' that can be used to query if a conversation has an available starting option
