### PR TITLE
Compatibility with HolographicDisplays now supports items defined in items.yml

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -22,6 +22,7 @@ import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -261,6 +262,16 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                                         LogUtils.getLogger().log(Level.WARNING, "Could not find item in " + line.substring(5).split(":")[0]
                                                 + " hologram: " + e.getMessage());
                                         LogUtils.logThrowable(e);
+                                        
+                                        //TODO Remove this code in the version 1.13 or later
+                                        //This support the old implementation of Items 
+                                        Material material = Material.matchMaterial(line.substring(5));
+                                        if(material != null) {
+                                            LogUtils.getLogger().log(Level.WARNING, "You use the Old method to define a hover item, this still work, but use the new method,"
+                                                    + " defining it as a BetonQuest Item in the items.yml. The compatibility will be removed in 1.13");
+                                            hologram.appendItemLine(new ItemStack(material));
+                                        }
+                                        //Remove up to here
                                     }
                                 } else {
                                     hologram.appendTextLine(line.replace('&', '§'));

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -21,6 +21,7 @@ import com.gmail.filoghost.holographicdisplays.api.Hologram;
 import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -120,6 +121,16 @@ public class HologramLoop {
                         } catch (ObjectNotFoundException e) {
                             LogUtils.getLogger().log(Level.WARNING, "Could not find item in " + key + " hologram: " + e.getMessage());
                             LogUtils.logThrowable(e);
+                            
+                            //TODO Remove this code in the version 1.13 or later
+                            //This support the old implementation of Items 
+                            Material material = Material.matchMaterial(line.substring(5));
+                            if(material != null) {
+                                LogUtils.getLogger().log(Level.WARNING, "You use the Old method to define a hover item, this still work, but use the new method,"
+                                        + " defining it as a BetonQuest Item in the items.yml. The compatibility will be removed in 1.13");
+                                hologram.appendItemLine(new ItemStack(material));
+                            }
+                            //Remove up to here
                         }
                     } else {
                         hologram.appendTextLine(line.replace('&', '§'));

--- a/BetonQuest-core/src/main/resources/changelog.txt
+++ b/BetonQuest-core/src/main/resources/changelog.txt
@@ -2,6 +2,7 @@ v1.12-dev
 Additions:
   * Condition 'wand' can now have an option 'amount'
 Changes:
+  * Items for HolographicDisplays are now defines in items.yml
 Fixes:
 
 v1.11-dev

--- a/docs/10-Compatibility.md
+++ b/docs/10-Compatibility.md
@@ -215,13 +215,13 @@ holograms:
   beton:
     lines:
     - '&bThis is Beton.'
-    - 'item:MAP'
+    - 'item:custom_item'
     - '&eBeton is strong.'
     location: 100;200;300;world
     conditions: has_some_quest, !finished_some_quest
 ```
 
-A line can also represent a floating item. To do so enter the line as 'item:`MATERIAL`'. It will be replaced with the `MATERIAL` defined. In the above example, a floating map will be seen between two lines of text.
+A line can also represent a floating item. To do so enter the line as 'item:`custom_item`'. It will be replaced with the `custom_item` defined defined in items.yml. If the Item is defined for example as map, a floating map will be seen between two lines of text.
 
 The holograms are updated every 10 seconds. If you want to make it faster, add `hologram_update_interval` option in _config.yml_ file and set it to a number of ticks you want to pass between updates (one second is 20 ticks). Don't set it to 0 or negative numbers, it will result in an error.
 


### PR DESCRIPTION
This feature add support, that you can define your items in the items.yml and set a amount of items in the custom.yml.
The amount only works at the moment with the code of this PR(filoghost/HolographicDisplays#224) and in the future when the PR is accepted, so we maybe need to wait a little bit.

This change is compatible with old HolographicDisplays versions, but then the amount is ignored.

Here is a little preview: https://cdn.discordapp.com/attachments/520955035832811521/620708922709377024/2019-09-09_21.53.58.png
There is also a video: https://drive.google.com/file/d/1bRmnnhVld9UT_9XfZMzusTRCtFLKPA35/view?usp=sharing
And a picture of multible Items in HolographicDisplays: https://cdn.discordapp.com/attachments/520955035832811521/622204749374029824/2019-09-14_00.58.13.png