### PR TITLE
Journal main page priority

### DIFF
--- a/BetonQuest-core/src/main/resources/changelog.txt
+++ b/BetonQuest-core/src/main/resources/changelog.txt
@@ -26,6 +26,7 @@ Additions:
 Changes:
   * Event 'effect' can have 'ambient', 'hidden' and 'noicon' parameters
   * Event 'effect' has '--ambient' parameter deprecated with a non fatal warning.
+  * Priority for 'journal_main_page' entries not unique anymore, it only orders the entries. Same priority sort it alphabetic
 Fixes:
   * Resolve variables in journal pages.
   * WATER and LAVA can be specified in Action Objective


### PR DESCRIPTION
This PR is a little bit more complicated, because it changes the logic of the Priority of journal_main_page.
I realized, that it makes not so much sens, that you have to manage, that you can only use each priority only once.

So here is a example:
On our Server we have a bunch of quests and we want to use the main page as a overview of all quests. So we decided, that the Priority 0 is a kind of legend. The prioritys 1-4 are for quests, that have stats like 'can started' 'started' 'finished'. But then we noticed that this is not possible, as mentioned above.

At this point i decided, to change this, so now it is possible to 'group' the main page. I din't know, if this it the best way to implement this, but i think so. If not, i think we have to search for a other solution.