### PR TITLE
Conversation: Change how conditions affect extends

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/Conversation.java
@@ -211,7 +211,7 @@ public class Conversation implements Listener {
             new ConversationEnder().runTask(BetonQuest.getInstance().getJavaPlugin());
             return;
         }
-        String text = data.getText(language, option, OptionType.NPC);
+        String text = data.getText(playerID, language, option, OptionType.NPC);
         // resolve variables
         for (String variable : BetonQuest.resolveVariables(text)) {
             text = text.replace(variable, plugin.getVariableValue(data.getPackName(), variable, playerID));
@@ -256,7 +256,7 @@ public class Conversation implements Listener {
             // print reply and put it to the hashmap
             current.put(Integer.valueOf(i), option);
             // replace variables with their values
-            String text = data.getText(language, option, OptionType.PLAYER);
+            String text = data.getText(playerID, language, option, OptionType.PLAYER);
             for (String variable : BetonQuest.resolveVariables(text)) {
                 text = text.replace(variable, plugin.getVariableValue(data.getPackName(), variable, playerID));
             }
@@ -563,10 +563,6 @@ public class Conversation implements Listener {
         }
 
         public void run() {
-            // fire events
-            for (EventID event : data.getEventIDs(option, OptionType.NPC)) {
-                BetonQuest.event(playerID, event);
-            }
             new OptionPrinter(option).runTaskAsynchronously(BetonQuest.getInstance().getJavaPlugin());
         }
     }
@@ -585,10 +581,6 @@ public class Conversation implements Listener {
         }
 
         public void run() {
-            // fire events
-            for (EventID event : data.getEventIDs(option, OptionType.PLAYER)) {
-                BetonQuest.event(playerID, event);
-            }
             new ResponsePrinter(option).runTaskAsynchronously(BetonQuest.getInstance().getJavaPlugin());
         }
     }
@@ -608,7 +600,7 @@ public class Conversation implements Listener {
 
         public void run() {
             // don't forget to select the option prior to printing its text
-            selectOption(data.getPointers(option, OptionType.PLAYER), false);
+            selectOption(data.getPointers(playerID, option, OptionType.PLAYER), false);
             // print to player npc's answer
             printNPCText();
             ConversationOptionEvent event = new ConversationOptionEvent(player, conv, option, conv.option);
@@ -618,6 +610,10 @@ public class Conversation implements Listener {
                 @Override
                 public void run() {
                     Bukkit.getServer().getPluginManager().callEvent(event);
+                    // fire events
+                    for (EventID event : data.getEventIDs(playerID, option, OptionType.PLAYER)) {
+                        BetonQuest.event(playerID, event);
+                    }
                 }
             }.runTask(BetonQuest.getInstance().getJavaPlugin());
         }
@@ -638,7 +634,12 @@ public class Conversation implements Listener {
 
         public void run() {
             // print options
-            printOptions(data.getPointers(option, OptionType.NPC));
+            printOptions(data.getPointers(playerID, option, OptionType.NPC));
+
+            // fire events
+            for (EventID event : data.getEventIDs(playerID, option, OptionType.NPC)) {
+                BetonQuest.event(playerID, event);
+            }
         }
     }
 

--- a/docs/05-Reference.md
+++ b/docs/05-Reference.md
@@ -84,7 +84,7 @@ If you're using the `chest` display method you can change the option's item to s
 In case you want to use a different type of conversation display for a specific conversation you can add `conversationIO: <type>` setting to the conversation file at the top of the YAML hierarchy, which is the same level as `quester` or `first` options).
 
 ### Advanced: Extends
-Conversation also supports the concept of inheritance. Any option can include the key `extends` with a comma delimited list of other options that will have their configuration merged. The extended options may themselves extend other options. Infinite loops are detected.
+Conversation also supports the concept of inheritance. Any option can include the key `extends` with a comma delimited list of other options of the same time. The first option that does not have any false conditions will have it's text, pointers and events merged with the extending option. The extended option may itself extend other options. Infinite loops are detected.
 
 ```YAML
 NPC_options:
@@ -92,17 +92,24 @@ NPC_options:
   ## Normal Conversation Start
   start:
     text: 'What can I do for you'
-    extends: today, main_menu
+    extends: tonight, today
     
   ## Useless addition as example
+  tonight:
+    # Always false
+    condition: random 0-1
+    text: ' tonight?'
+    extends: main_menu
+
   today:
     text: ' today?'
+    extends: main_menu
 
   ## Main main_menu
  main_menu:
    pointers: i_have_questions, bye
 ```
-In the above example, the option _start_ is extended by both _today_ and _main_menu_. It will have the pointers in main_menu added to it just as if they were defined directly in it and the text will be joined together. If you structure your conversation correctly you can make use of this to minimize duplication.
+In the above example, the option _start_ is extended by both _tonight_ and _today_, both of whom are extended by _main_menu_. As _tonight_ has a false condition the _today_ option will win. The _start_ option will have the pointers in main_menu added to it just as if they were defined directly in it and the text will be joined together from _today_. If you structure your conversation correctly you can make use of this to minimize duplication.
 
 ***
 


### PR DESCRIPTION
## Overview

An extends keyword in a conversation allows an option to then be extended by another option of the same type. Used correctly this can cut down on duplication.

Originally when I added this keyword it's purpose was to simple add the extended options directly to the extended option, just as if one had added the events, conditions, pointers and text directly to it.

This PR changes this slightly so that an extends keyword will find the first option in the list that has all conditions as true for the player and will then add the text, events and pointers to it. In some ways this behaves a bit like the `first` keyword in a conversation.