### PR TITLE
Better Chat Interceptor

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -90,8 +90,10 @@ import pl.betoncraft.betonquest.conversation.ConversationData;
 import pl.betoncraft.betonquest.conversation.ConversationIO;
 import pl.betoncraft.betonquest.conversation.ConversationResumer;
 import pl.betoncraft.betonquest.conversation.CubeNPCListener;
+import pl.betoncraft.betonquest.conversation.Interceptor;
 import pl.betoncraft.betonquest.conversation.InventoryConvIO;
 import pl.betoncraft.betonquest.conversation.SimpleConvIO;
+import pl.betoncraft.betonquest.conversation.SimpleInterceptor;
 import pl.betoncraft.betonquest.conversation.SlowTellrawConvIO;
 import pl.betoncraft.betonquest.conversation.TellrawConvIO;
 import pl.betoncraft.betonquest.database.Database;
@@ -219,6 +221,7 @@ public class BetonQuest extends VersionPlugin {
     private static HashMap<String, Class<? extends QuestEvent>> eventTypes = new HashMap<>();
     private static HashMap<String, Class<? extends Objective>> objectiveTypes = new HashMap<>();
     private static HashMap<String, Class<? extends ConversationIO>> convIOTypes = new HashMap<>();
+    private static HashMap<String, Class<? extends Interceptor>> interceptorTypes = new HashMap<>();
     private static HashMap<String, Class<? extends NotifyIO>> notifyIOTypes = new HashMap<>();
     private static HashMap<String, Class<? extends Variable>> variableTypes = new HashMap<>();
     private static HashMap<ConditionID, Condition> conditions = new HashMap<>();
@@ -680,6 +683,9 @@ public class BetonQuest extends VersionPlugin {
         registerConversationIO("combined", InventoryConvIO.Combined.class);
         registerConversationIO("slowtellraw", SlowTellrawConvIO.class);
 
+        // register interceptor types
+        registerInterceptor("simple", SimpleInterceptor.class);
+
         // register notify IO types
         registerNotifyIO("suppress", SuppressNotifyIO.class);
         registerNotifyIO("chat", ChatNotifyIO.class);
@@ -1100,6 +1106,17 @@ public class BetonQuest extends VersionPlugin {
     }
 
     /**
+     * Registers new interceptor class.
+     *
+     * @param name             name of the interceptor type
+     * @param interceptorClass class object to register
+     */
+    public void registerInterceptor(String name, Class<? extends Interceptor> interceptorClass) {
+        Debug.info("Registering " + name + " interceptor type");
+        interceptorTypes.put(name, interceptorClass);
+    }
+
+    /**
      * Registers new notify input/output class.
      *
      * @param name    name of the IO type
@@ -1174,6 +1191,14 @@ public class BetonQuest extends VersionPlugin {
      */
     public Class<? extends ConversationIO> getConvIO(String name) {
         return convIOTypes.get(name);
+    }
+
+    /**
+     * @param name name of the interceptor type
+     * @return the class object for this interceptor type
+     */
+    public Class<? extends Interceptor> getInterceptor(String name) {
+        return interceptorTypes.get(name);
     }
 
     /**

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/protocollib/ProtocolLibIntegrator.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/protocollib/ProtocolLibIntegrator.java
@@ -21,6 +21,7 @@ import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.compatibility.Compatibility;
 import pl.betoncraft.betonquest.compatibility.Integrator;
 import pl.betoncraft.betonquest.compatibility.protocollib.conversation.MenuConvIO;
+import pl.betoncraft.betonquest.compatibility.protocollib.conversation.PacketInterceptor;
 
 
 public class ProtocolLibIntegrator implements Integrator {
@@ -39,6 +40,7 @@ public class ProtocolLibIntegrator implements Integrator {
             plugin.registerEvents("updatevisibility", UpdateVisibilityNowEvent.class);
         }
         plugin.registerConversationIO("menu", MenuConvIO.class);
+        plugin.registerInterceptor("packet", PacketInterceptor.class);
     }
 
     @Override

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/protocollib/conversation/PacketInterceptor.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/protocollib/conversation/PacketInterceptor.java
@@ -1,0 +1,106 @@
+/*
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.betoncraft.betonquest.compatibility.protocollib.conversation;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.compatibility.protocollib.wrappers.WrapperPlayServerChat;
+import pl.betoncraft.betonquest.conversation.Conversation;
+import pl.betoncraft.betonquest.conversation.Interceptor;
+import pl.betoncraft.betonquest.utils.PlayerConverter;
+
+import java.util.ArrayList;
+
+/**
+ * Provide a packet interceptor to get all chat packets to player
+ */
+public class PacketInterceptor implements Interceptor, Listener {
+
+    protected final Conversation conv;
+    protected final Player player;
+    private ArrayList<WrapperPlayServerChat> messages = new ArrayList<>();
+    private PacketAdapter packetAdapter;
+
+    public PacketInterceptor(Conversation conv, String playerID) {
+        this.conv = conv;
+        this.player = PlayerConverter.getPlayer(playerID);
+
+        // Intercept Packets
+        packetAdapter = new PacketAdapter(BetonQuest.getInstance().getJavaPlugin(), ListenerPriority.HIGHEST,
+                PacketType.Play.Server.CHAT
+
+        ) {
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                if (event.getPlayer() != player) {
+                    return;
+                }
+
+                if (event.getPacketType().equals(PacketType.Play.Server.CHAT)) {
+                    PacketContainer packet = event.getPacket();
+                    BaseComponent[] bc = (BaseComponent[]) packet.getModifier().read(1);
+                    if (bc != null) {
+                        String message = TextComponent.toLegacyText(bc);
+                        // Tagged packet, remove tag and let through
+                        if (message.contains("_bq_")) {
+                            packet.getModifier().write(1, new BaseComponent[]{new TextComponent(message.replace("_bq_", ""))});
+                            event.setPacket(packet);
+                            return;
+                        }
+                    }
+
+                    WrapperPlayServerChat chat = new WrapperPlayServerChat(event.getPacket());
+                    event.setCancelled(true);
+                    messages.add(chat);
+                }
+            }
+        };
+
+        ProtocolLibrary.getProtocolManager().addPacketListener(packetAdapter);
+    }
+
+    /**
+     * Send message, bypassing Interceptor
+     */
+    @Override
+    public void sendMessage(String message) {
+        // Tag the message. Is there a better way?
+        player.spigot().sendMessage(TextComponent.fromLegacyText("_bq_" + message));
+    }
+
+    @Override
+    public void end() {
+        // Stop Listening for Packets
+        ProtocolLibrary.getProtocolManager().removePacketListener(packetAdapter);
+
+        // Send all messages to player
+        for (WrapperPlayServerChat message : messages) {
+            message.sendPacket(player);
+        }
+    }
+}

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/ChatConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/ChatConvIO.java
@@ -146,7 +146,7 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
         String message = event.getMessage().trim();
         for (int i : options.keySet()) {
             if (message.equals(Integer.toString(i))) {
-                player.sendMessage(answerFormat + options.get(i));
+                conv.sendMessage(answerFormat + options.get(i));
                 conv.passPlayerAnswer(i);
                 event.setCancelled(true);
                 return;
@@ -179,7 +179,7 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
             end();
             return;
         }
-        player.sendMessage(Utils.replaceReset(textFormat.replace("%npc%", npcName) + npcText, npcTextColor));
+        conv.sendMessage(Utils.replaceReset(textFormat.replace("%npc%", npcName) + npcText, npcTextColor));
     }
 
     @Override
@@ -197,7 +197,7 @@ public abstract class ChatConvIO implements ConversationIO, Listener {
     @Override
     public void print(String message) {
         if (message != null && message.length() > 0) {
-            player.sendMessage(message);
+            conv.sendMessage(message);
         }
     }
 }

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/ConversationData.java
@@ -54,6 +54,7 @@ public class ConversationData {
     private String[] startingOptions;
     private boolean blockMovement;
     private String convIO;
+    private String interceptor;
 
     private HashMap<String, Option> NPCOptions;
     private HashMap<String, Option> playerOptions;
@@ -98,20 +99,30 @@ public class ConversationData {
         String rawStartingOptions = pack.getString("conversations." + name + ".first");
         String stop = pack.getString("conversations." + name + ".stop");
         blockMovement = stop != null && stop.equalsIgnoreCase("true");
-        String rawConvIO = pack.getString("conversations." + name + ".conversationIO", BetonQuest.getInstance().getConfig().getString("default_conversation_IO"));
+        String rawConvIO = pack.getString("conversations." + name + ".conversationIO", BetonQuest.getInstance().getConfig().getString("default_conversation_IO", "menu,chest"));
+        String rawInterceptor = pack.getString("conversations." + name + ".interceptor", BetonQuest.getInstance().getConfig().getString("default_interceptor", "packet,simple"));
 
         // check if all data is valid (or at least exist)
-        if (rawConvIO != null) {
-            for (String s : rawConvIO.split(",")) {
-                if (BetonQuest.getInstance().getConvIO(s.trim()) != null) {
-                    convIO = s.trim();
-                    break;
-                }
+        for (String s : rawConvIO.split(",")) {
+            if (BetonQuest.getInstance().getConvIO(s.trim()) != null) {
+                convIO = s.trim();
+                break;
             }
         }
         if (convIO == null) {
             throw new InstructionParseException("No registered conversation IO found: " + rawConvIO);
         }
+
+        for (String s : rawInterceptor.split(",")) {
+            if (BetonQuest.getInstance().getInterceptor(s.trim()) != null) {
+                interceptor = s.trim();
+                break;
+            }
+        }
+        if (interceptor == null) {
+            throw new InstructionParseException("No registered interceptor found: " + rawInterceptor);
+        }
+
         if (quester == null || quester.isEmpty()) {
             throw new InstructionParseException("Quester's name is not defined");
         }
@@ -319,6 +330,13 @@ public class ConversationData {
      */
     public String getConversationIO() {
         return convIO;
+    }
+
+    /**
+     * @return the Interceptor
+     */
+    public String getInterceptor() {
+        return interceptor;
     }
 
     public String getText(String lang, String option, OptionType type) {

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/Interceptor.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/Interceptor.java
@@ -1,0 +1,32 @@
+/*
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.betoncraft.betonquest.conversation;
+
+public interface Interceptor {
+
+    /**
+     * Send message to player bypassing Interceptor
+     */
+    void sendMessage(String message);
+
+    /**
+     * Ends the work of this interceptor
+     */
+    void end();
+}

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/InventoryConvIO.java
@@ -245,7 +245,7 @@ public class InventoryConvIO implements Listener, ConversationIO {
             buttons[j] = item;
         }
         if (printMessages)
-            player.sendMessage(npcNameColor + npcName + ChatColor.RESET + ": " + npcTextColor + response);
+            conv.sendMessage(npcNameColor + npcName + ChatColor.RESET + ": " + npcTextColor + response);
         inv.setContents(buttons);
         new BukkitRunnable() {
             @Override
@@ -280,7 +280,7 @@ public class InventoryConvIO implements Listener, ConversationIO {
             String message = options.get(choosen);
             if (message != null) {
                 processingLastClick = true;
-                if (printMessages) player.sendMessage(answerPrefix + message);
+                if (printMessages) conv.sendMessage(answerPrefix + message);
                 conv.passPlayerAnswer(choosen);
             }
         }

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/SimpleConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/SimpleConvIO.java
@@ -45,7 +45,7 @@ public class SimpleConvIO extends ChatConvIO {
     public void display() {
         super.display();
         for (int i = 1; i <= options.size(); i++) {
-            player.sendMessage(optionFormat.replace("%number%", Integer.toString(i)) + options.get(i));
+            conv.sendMessage(optionFormat.replace("%number%", Integer.toString(i)) + options.get(i));
         }
     }
 }

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/SimpleInterceptor.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/SimpleInterceptor.java
@@ -1,0 +1,85 @@
+/*
+ * BetonQuest - advanced quests for Bukkit
+ * Copyright (C) 2016  Jakub "Co0sh" Sapalski
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.betoncraft.betonquest.conversation;
+
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import pl.betoncraft.betonquest.BetonQuest;
+import pl.betoncraft.betonquest.utils.Debug;
+import pl.betoncraft.betonquest.utils.PlayerConverter;
+
+import java.util.ArrayList;
+
+public class SimpleInterceptor implements Interceptor, Listener {
+
+    protected final Conversation conv;
+    protected final Player player;
+    private ArrayList<String> messages = new ArrayList<>();
+
+    public SimpleInterceptor(Conversation conv, String playerID) {
+        this.conv = conv;
+        this.player = PlayerConverter.getPlayer(playerID);
+        Bukkit.getPluginManager().registerEvents(this, BetonQuest.getInstance().getJavaPlugin());
+    }
+
+    /**
+     * Send message, bypassing Interceptor
+     */
+    @Override
+    public void sendMessage(String message) {
+        player.spigot().sendMessage(TextComponent.fromLegacyText(message));
+    }
+
+    /**
+     * This method prevents concurrent list modification
+     */
+    private synchronized void addMessage(String message) {
+        messages.add(message);
+    }
+
+    @Override
+    public void end() {
+        HandlerList.unregisterAll(this);
+
+        // Send all messages to player
+        for (String message : messages) {
+            player.sendMessage(message);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onChat(AsyncPlayerChatEvent event) {
+        Debug.error(event.getMessage());
+        // store all messages so they can be displayed to the player
+        // once the conversation is finished
+        if (event.isCancelled()) {
+            return;
+        }
+        if (event.getPlayer() != player && event.getRecipients().contains(player)) {
+            event.getRecipients().remove(player);
+            addMessage(String.format(event.getFormat(), event.getPlayer().getDisplayName(), event.getMessage()));
+        }
+    }
+}

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/SlowTellrawConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/SlowTellrawConvIO.java
@@ -84,7 +84,7 @@ public class SlowTellrawConvIO extends TellrawConvIO {
                     return;
                 }
 
-                player.sendMessage(lines.remove(0));
+                conv.sendMessage(lines.remove(0));
             }
         }.runTaskTimer(BetonQuest.getInstance().getJavaPlugin(), 0, 2);
     }

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/TellrawConvIO.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/conversation/TellrawConvIO.java
@@ -81,7 +81,7 @@ public class TellrawConvIO extends ChatConvIO {
         String hash = parts[1];
         for (int j = 1; j <= hashes.size(); j++) {
             if (hashes.get(j).equals(hash)) {
-                player.sendMessage(answerFormat + options.get(j));
+                conv.sendMessage(answerFormat + options.get(j));
                 conv.passPlayerAnswer(j);
                 return;
             }

--- a/BetonQuest-core/src/main/resources/changelog.txt
+++ b/BetonQuest-core/src/main/resources/changelog.txt
@@ -23,6 +23,7 @@ Additions:
   * New Notification System
   * New 'notify' event - Create custom notifications on the ActionBar, BossBar, Title, Subtitle and Achievement
   * New 'menu' conversation IO - Requires ProtocolLib. See: https://www.youtube.com/watch?v=Qtn7Dpdf4jw&lc
+  * New 'packet' chat interceptor - Requires ProtocolLib.
 Changes:
   * Event 'effect' can have 'ambient', 'hidden' and 'noicon' parameters
   * Event 'effect' has '--ambient' parameter deprecated with a non fatal warning.

--- a/BetonQuest-core/src/main/resources/config.yml
+++ b/BetonQuest-core/src/main/resources/config.yml
@@ -15,6 +15,7 @@ default_journal_slot: '-1'
 max_npc_distance: '5'
 citizens_npcs_by_name: 'false'
 default_conversation_IO: menu,chest
+default_interceptor: packet,simple
 display_chat_after_conversation: 'true'
 combat_delay: '10'
 notify_pullback: 'true'

--- a/BetonQuest-v1.8/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/BetonQuest-v1.8/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -88,8 +88,10 @@ import pl.betoncraft.betonquest.conversation.ConversationData;
 import pl.betoncraft.betonquest.conversation.ConversationIO;
 import pl.betoncraft.betonquest.conversation.ConversationResumer;
 import pl.betoncraft.betonquest.conversation.CubeNPCListener;
+import pl.betoncraft.betonquest.conversation.Interceptor;
 import pl.betoncraft.betonquest.conversation.InventoryConvIO;
 import pl.betoncraft.betonquest.conversation.SimpleConvIO;
+import pl.betoncraft.betonquest.conversation.SimpleInterceptor;
 import pl.betoncraft.betonquest.conversation.SlowTellrawConvIO;
 import pl.betoncraft.betonquest.conversation.TellrawConvIO;
 import pl.betoncraft.betonquest.database.Database;
@@ -216,6 +218,7 @@ public class BetonQuest extends VersionPlugin {
     private static HashMap<String, Class<? extends QuestEvent>> eventTypes = new HashMap<>();
     private static HashMap<String, Class<? extends Objective>> objectiveTypes = new HashMap<>();
     private static HashMap<String, Class<? extends ConversationIO>> convIOTypes = new HashMap<>();
+    private static HashMap<String, Class<? extends Interceptor>> interceptorTypes = new HashMap<>();
     private static HashMap<String, Class<? extends NotifyIO>> notifyIOTypes = new HashMap<>();
     private static HashMap<String, Class<? extends Variable>> variableTypes = new HashMap<>();
     private static HashMap<ConditionID, Condition> conditions = new HashMap<>();
@@ -674,6 +677,9 @@ public class BetonQuest extends VersionPlugin {
         registerConversationIO("combined", InventoryConvIO.Combined.class);
         registerConversationIO("slowtellraw", SlowTellrawConvIO.class);
 
+        // register interceptor types
+        registerInterceptor("simple", SimpleInterceptor.class);
+
         // register notify IO types
         registerNotifyIO("suppress", SuppressNotifyIO.class);
         registerNotifyIO("chat", ChatNotifyIO.class);
@@ -1094,6 +1100,17 @@ public class BetonQuest extends VersionPlugin {
     }
 
     /**
+     * Registers new interceptor class.
+     *
+     * @param name             name of the interceptor type
+     * @param interceptorClass class object to register
+     */
+    public void registerInterceptor(String name, Class<? extends Interceptor> interceptorClass) {
+        Debug.info("Registering " + name + " interceptor type");
+        interceptorTypes.put(name, interceptorClass);
+    }
+
+    /**
      * Registers new notify input/output class.
      *
      * @param name    name of the IO type
@@ -1168,6 +1185,14 @@ public class BetonQuest extends VersionPlugin {
      */
     public Class<? extends ConversationIO> getConvIO(String name) {
         return convIOTypes.get(name);
+    }
+
+    /**
+     * @param name name of the interceptor type
+     * @return the class object for this interceptor type
+     */
+    public Class<? extends Interceptor> getInterceptor(String name) {
+        return interceptorTypes.get(name);
     }
 
     /**

--- a/BetonQuest-v1.9/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
+++ b/BetonQuest-v1.9/src/main/java/pl/betoncraft/betonquest/BetonQuest.java
@@ -89,8 +89,10 @@ import pl.betoncraft.betonquest.conversation.ConversationData;
 import pl.betoncraft.betonquest.conversation.ConversationIO;
 import pl.betoncraft.betonquest.conversation.ConversationResumer;
 import pl.betoncraft.betonquest.conversation.CubeNPCListener;
+import pl.betoncraft.betonquest.conversation.Interceptor;
 import pl.betoncraft.betonquest.conversation.InventoryConvIO;
 import pl.betoncraft.betonquest.conversation.SimpleConvIO;
+import pl.betoncraft.betonquest.conversation.SimpleInterceptor;
 import pl.betoncraft.betonquest.conversation.SlowTellrawConvIO;
 import pl.betoncraft.betonquest.conversation.TellrawConvIO;
 import pl.betoncraft.betonquest.database.Database;
@@ -217,6 +219,7 @@ public class BetonQuest extends VersionPlugin {
     private static HashMap<String, Class<? extends QuestEvent>> eventTypes = new HashMap<>();
     private static HashMap<String, Class<? extends Objective>> objectiveTypes = new HashMap<>();
     private static HashMap<String, Class<? extends ConversationIO>> convIOTypes = new HashMap<>();
+    private static HashMap<String, Class<? extends Interceptor>> interceptorTypes = new HashMap<>();
     private static HashMap<String, Class<? extends NotifyIO>> notifyIOTypes = new HashMap<>();
     private static HashMap<String, Class<? extends Variable>> variableTypes = new HashMap<>();
     private static HashMap<ConditionID, Condition> conditions = new HashMap<>();
@@ -676,6 +679,9 @@ public class BetonQuest extends VersionPlugin {
         registerConversationIO("combined", InventoryConvIO.Combined.class);
         registerConversationIO("slowtellraw", SlowTellrawConvIO.class);
 
+        // register interceptor types
+        registerInterceptor("simple", SimpleInterceptor.class);
+
         // register notify IO types
         registerNotifyIO("suppress", SuppressNotifyIO.class);
         registerNotifyIO("chat", ChatNotifyIO.class);
@@ -1096,6 +1102,17 @@ public class BetonQuest extends VersionPlugin {
     }
 
     /**
+     * Registers new interceptor class.
+     *
+     * @param name             name of the interceptor type
+     * @param interceptorClass class object to register
+     */
+    public void registerInterceptor(String name, Class<? extends Interceptor> interceptorClass) {
+        Debug.info("Registering " + name + " interceptor type");
+        interceptorTypes.put(name, interceptorClass);
+    }
+
+    /**
      * Registers new notify input/output class.
      *
      * @param name    name of the IO type
@@ -1170,6 +1187,14 @@ public class BetonQuest extends VersionPlugin {
      */
     public Class<? extends ConversationIO> getConvIO(String name) {
         return convIOTypes.get(name);
+    }
+
+    /**
+     * @param name name of the interceptor type
+     * @return the class object for this interceptor type
+     */
+    public Class<? extends Interceptor> getInterceptor(String name) {
+        return interceptorTypes.get(name);
     }
 
     /**

--- a/docs/02-Installation-and-Configuration.md
+++ b/docs/02-Installation-and-Configuration.md
@@ -27,6 +27,7 @@ The configuration of BetonQuest is done mainly in _config.yml_ file. All options
 * `citizens_npcs_by_name` sets whether NPCs from citizens2 should be identified in main.yml by their name instead of their id.
 * `max_npc_distance` is the distance you need to walk away from the NPC for the conversation to end (in the case of using chat-based conversation interface).
 * `default_conversation_IO` is a comma-separated list of conversation interfaces with the first valid one used. `simple` is a conversation in chat. `tellraw` is an extension to provide clickable options, and `chest` is a conversation in inventory window. If you want to use chest and also write the conversation to the players chat, use `combined`. Others, like `menu` are available if you have the required plugins and other plugins can add additional IO types.
+* `default_interceptor` is a comma-separated list of chat interceptors with the first valid one used. `simple` attempts to catch chat events. `packet` uses protocollib to intercept packets before they reach the player. 
 * `display_chat_after_conversation` this will prevent all chat messages from displaying during a conversation and it will show them once it's finished.
 * `combat_delay` is a delay (in seconds) the player must wait before starting a conversation after combat.
 * `notify_pullback` will display a message every time the player is pulled back by the `stop` option in conversations (in the case of chat-based conversations). It notifies players that they are in a conversation, and the pullback is not a bug.

--- a/docs/05-Reference.md
+++ b/docs/05-Reference.md
@@ -10,6 +10,7 @@ Each conversation must define name of the NPC (some conversations can be not bou
     first: option1, option2
     stop: 'true'
     final_events: event1, event2
+    interceptor: simple
     NPC_options:
       option1:
         text: Some text in default language
@@ -35,6 +36,7 @@ Note 1: _Configuration files use YAML syntax. Google it if you don't know anythi
 * `first` are pointers to options the NPC will use at the beginning of the conversation. He will choose the first one that meets all conditions. You define these options in `npc_options` branch.
 * `final_events` are events that will fire on conversation end, no matter how it ends (so you can create e.g. guards attacking the player if he tries to run). You can leave this option out if you don't need any final events.
 * `stop` determines if player can move away from an NPC while in this conversation (false) or if he's stopped every time he tries to (true). If enabled, it will also suspend the conversation when the player quits, and resume it after he joins back in. This way he will have to finish his conversation no matter what. _It needs to be in `''`!_ You can modify the distance at which the conversation is ended / player is moved back with `max_npc_distance` option in the _config.yml_.
+* `interceptor` optionally set a chat interceptor for this conversation. Multiple interceptors can be provided in a comma-separated list with the first valid one used.
 * `NPC_options` is a branch with texts said by the NPC.
 * `player_options` is a branch with options the player can choose.
 * `text` defines what will display on screen. If you don't want to set any events/conditions/pointers to the option, just skip them. Only `text` is always required.
@@ -114,6 +116,11 @@ In the above example, the option _start_ is extended by both _tonight_ and _toda
 ***
 
 Conditions, events and objectives are defined with an "instruction string". It's a piece of text, formatted in a specific way, containing the instruction for the condition/event/objective. Thanks to this string they know what should they do. To define the instruction string you will need a reference, few pages below. It describes how something behaves and how it should be created. All instruction strings are defined in appropriate files, for example all conditions are in _conditions.yml_ config. The syntax used to define them looks like this: `name: 'the instruction string containing the data'`. Apostrophes are optional in most cases, you can find out when to use them by looking up "YAML syntax" in Google.
+
+## Chat Interceptors
+During chat it can be distracting when messages from other players or system message interfere with the dialogue. A chat interceptor provides a method of intercepting these message and then playing them back later.
+
+A default chat interceptor is specified in `config.yml` by setting `default_interceptor`. This defaults to `simple` for the simple interceptor. The chat interceptor can also be set per conversation though the use of `interceptor` key in the conversation. 
 
 ## Conditions
 

--- a/docs/10-Compatibility.md
+++ b/docs/10-Compatibility.md
@@ -438,6 +438,10 @@ Variables:
   * {option_text} - The option text
   * {npc_name} - The name of the NPC
 
+### Chat Interceptor: `packet`
+
+Intercept pretty much anything sent to the player by intercepting packets sent to them. This can be enabled by default by setting the `default_interceptor` to `packet` in config.yml or per conversation by setting `interceptor` to `packet` in the top level of the conversation.
+
 ## [Quests](http://dev.bukkit.org/bukkit-plugins/quests/)
 
 Quests is another questing plugin, which offers very simple creation of quests. If you don't want to spend a lot of time to write advanced quests in BetonQuest but you need a specific thing from this plugin you can use Custom Event Reward or Custom Condition Requirement. Alternatively, if you have a lot of quests written in Quests, but want to integrate them with the conversation system, you can use `quest` event and `quest` condition.


### PR DESCRIPTION
## Overview

Presently capturing chat events during conversation is error prone due to 3rd party plugins sending data in uncatchable ways.

This PR provides a ProtocolLib interceptor that will catch all server sent message to the client. These can then be played back verbatim after a conversation.

If ProtcolLib is not available the old method will be used instead.