### PR TITLE
Fix for multiversion bug

### DIFF
--- a/BetonQuest-v1.12/src/main/java/pl/betoncraft/betonquest/config/Config.java
+++ b/BetonQuest-v1.12/src/main/java/pl/betoncraft/betonquest/config/Config.java
@@ -395,18 +395,16 @@ public class Config
 	 * @return the ID of the conversation assigned to this NPC or null if there
 	 *         isn't one
 	 */
-	public static String getNpc(String value)
-	{
+	public static String getNpc(String value) {
 		// load npc assignments from all packages
-		for(String packName : packages.keySet())
-		{
+		for (String packName : packages.keySet()) {
 			ConfigPackage pack = packages.get(packName);
-			ConfigurationSection assignemnts = pack.getMain().getConfig().getConfigurationSection("npcs");
-			for(String assignment : assignemnts.getKeys(false))
-			{
-				if(assignment.equalsIgnoreCase(value))
-				{
-					return packName + "." + assignemnts.getString(assignment);
+			ConfigurationSection assignments = pack.getMain().getConfig().getConfigurationSection("npcs");
+			if (assignments != null) {
+				for (String assignment : assignments.getKeys(false)) {
+					if (assignment.equalsIgnoreCase(value)) {
+						return packName + "." + assignments.getString(assignment);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The `getNPC` method from the 1.12 version of Config.java was using unchecked values that can be null. This was a simple fix, I just copied the method from the BetonQuestCore's Config.java. It just included the required check for null, nothing else is different.